### PR TITLE
Add PDF document signing with deferred signing and timestamp support

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,166 +1,62 @@
-# EasyCodeSign
+# CLAUDE.md
 
-A Ruby gem for signing and verifying zip files and Ruby gems using hardware token-based signatures (HSM/smart cards).
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Project Overview
+## Project
 
-**Purpose**: Provide a clean, extensible interface for code signing and verification operations using hardware security tokens, starting with SafeNet eToken support.
+EasyCodeSign is a Ruby gem for signing and verifying Ruby gems, ZIP archives, and PDF documents using hardware security tokens (HSM/smart cards) via PKCS#11. Currently supports SafeNet eToken.
 
-**Key Features**:
-- Sign Ruby gems (.gem files)
-- Sign ZIP archives
-- **Verify signatures on signed artifacts**
-- Hardware token integration via PKCS#11
-- **RFC 3161 timestamp authority support**
-- Extensible provider architecture for future token types
+- Ruby 3.2+ required
+- Entry point: `lib/easy_code_sign.rb`
+- CLI executable: `exe/easysign` (Thor-based)
+- Version in `lib/easy_code_sign/version.rb`
+
+## Commands
+
+```bash
+bundle exec rake test          # Run all tests
+bundle exec rake rubocop       # Run linter
+bundle exec rake               # Run both (default task)
+bundle exec ruby -Ilib:test test/signable_test.rb                    # Run single test file
+bundle exec ruby -Ilib:test test/signable_test.rb --name test_name   # Run single test method
+bin/console                    # Interactive console (IRB with gem loaded)
+bundle exec rake install       # Install gem locally
+```
+
+## Code Style
+
+- **Minitest** for testing (not RSpec, despite RSpec being in the Gemfile)
+- All tests inherit from `EasyCodeSignTest` (defined in `test/test_helper.rb`), which resets configuration/provider state between tests
+- **Double quotes** enforced for strings and interpolation (`.rubocop.yml`)
+- `frozen_string_literal: true` at top of all Ruby files
 
 ## Architecture
 
-```
-lib/
-├── easy_code_sign.rb              # Main entry point, configuration
-├── easy_code_sign/
-│   ├── version.rb                 # Gem version
-│   ├── configuration.rb           # Global configuration
-│   ├── signer.rb                  # Main signing orchestrator
-│   ├── verifier.rb                # Signature verification orchestrator
-│   ├── errors.rb                  # Custom error classes
-│   │
-│   ├── providers/                 # Token provider abstraction
-│   │   ├── base.rb                # Abstract base provider
-│   │   ├── safenet.rb             # SafeNet eToken implementation
-│   │   └── pkcs11_base.rb         # Shared PKCS#11 functionality
-│   │
-│   ├── signable/                  # Signable file type handlers
-│   │   ├── base.rb                # Abstract base for signable types
-│   │   ├── gem_file.rb            # Ruby gem signing logic
-│   │   └── zip_file.rb            # ZIP archive signing logic
-│   │
-│   ├── verification/              # Verification subsystem
-│   │   ├── result.rb              # Verification result object
-│   │   ├── certificate_chain.rb   # Certificate chain validation
-│   │   ├── signature_checker.rb   # Cryptographic signature validation
-│   │   └── trust_store.rb         # Trusted certificate management
-│   │
-│   ├── timestamp/                 # Timestamping support
-│   │   ├── client.rb              # TSA client (RFC 3161)
-│   │   ├── response.rb            # Timestamp response handling
-│   │   └── verifier.rb            # Timestamp verification
-│   │
-│   └── cli.rb                     # Command-line interface
-```
+Three-layer design with orchestrators delegating to subsystems:
 
-## Implementation Plan
+**Orchestrators** (`signer.rb`, `verifier.rb`) — coordinate the full signing/verification workflow. `EasyCodeSign.sign()` and `EasyCodeSign.verify()` are the primary API entry points.
 
-### Phase 1: Foundation
-1. [ ] Initialize gem structure with bundler
-2. [ ] Set up configuration system
-3. [ ] Define error hierarchy
-4. [ ] Create abstract provider interface
+**Provider pattern** (`providers/`) — abstracts hardware token communication. `Base` → `Pkcs11Base` → `Safenet`. New HSM support = new provider class inheriting `Pkcs11Base`. Providers manage PKCS#11 sessions, PIN auth, and delegate signing to the hardware token.
 
-### Phase 2: PKCS#11 Integration
-5. [ ] Integrate pkcs11 gem for hardware token communication
-6. [ ] Implement SafeNet provider
-7. [ ] Handle PIN entry securely
-8. [ ] Support certificate chain retrieval from token
+**Signable pattern** (`signable/`) — each file type has its own signing/verification strategy:
+- `GemFile` — PKCS#7 detached signatures on data.tar.gz, metadata.gz, checksums.yaml.gz
+- `ZipFile` — JAR-style META-INF/ manifest signing (MANIFEST.MF → CERT.SF → CERT.RSA)
+- `PdfFile` — HexaPDF ByteRange-based signing with deferred signing callback
 
-### Phase 3: Signing Operations
-9. [ ] Implement gem file signing (compatible with `gem cert`)
-10. [ ] Implement ZIP signing (detached signature + manifest)
-11. [ ] Create unified Signer interface
+**Verification subsystem** (`verification/`) — `Result` carries detailed status (signature, integrity, chain, trust, timestamp, revocation). `TrustStore` wraps OpenSSL CA store. `CertificateChain` does OCSP/CRL revocation checking. `SignatureChecker` verifies PKCS#7 signatures.
 
-### Phase 4: Timestamping
-12. [ ] Implement RFC 3161 timestamp client
-13. [ ] Support configurable TSA URLs (DigiCert, GlobalSign, etc.)
-14. [ ] Embed timestamps in signatures
-15. [ ] Handle TSA authentication (if required)
+**Timestamp subsystem** (`timestamp/`) — RFC 3161 client/request/response/verifier for timestamping signatures via TSA servers.
 
-### Phase 5: Verification
-16. [ ] Create VerificationResult class with detailed status
-17. [ ] Implement signature verification for gems
-18. [ ] Implement signature verification for ZIP files
-19. [ ] Certificate chain validation (root → intermediate → leaf)
-20. [ ] Certificate revocation checking (CRL/OCSP)
-21. [ ] Timestamp verification and validation
-22. [ ] Trust store management (system + custom trusted certs)
+**Key flow**: `EasyCodeSign.sign()` → `Signer` → detects file type → creates `Signable` → opens provider session → `signable.content_to_sign` → `provider.sign(data)` → optionally requests timestamp → `signable.apply_signature()`.
 
-### Phase 6: CLI & Polish
-23. [ ] Build CLI with Thor or OptionParser
-24. [ ] Add comprehensive error messages
-25. [ ] Documentation and examples
+## Error Hierarchy
 
-## Technical Decisions
+All errors inherit from `EasyCodeSign::Error`. Granular subclasses in `errors.rb` cover token, signing, verification, timestamp, and PDF errors. Some carry metadata (e.g., `PinError#retries_remaining`, `Pkcs11Error#pkcs11_error_code`, `TimestampAuthorityError#http_status`).
 
-### PKCS#11 Library
-Use the `pkcs11` gem which provides Ruby bindings to PKCS#11 libraries. SafeNet tokens typically use:
-- macOS: `/usr/local/lib/libeToken.dylib`
-- Linux: `/usr/lib/libeToken.so`
-- Windows: `eToken.dll`
+## Adding a New Signable File Type
 
-### Signature Format
-- **Ruby Gems**: Follow standard gem signing format (SHA256/SHA512 with RSA)
-- **ZIP Files**: Use JAR-style signing with META-INF/SIGNATURE.SF manifest
-
-### Timestamping (RFC 3161)
-Timestamps prove signature existed at a specific time, allowing verification even after certificate expiry:
-```ruby
-EasyCodeSign.configure do |config|
-  config.timestamp_authority = 'http://timestamp.digicert.com'
-  config.timestamp_hash_algorithm = :sha256
-end
-```
-
-Common TSA endpoints:
-- DigiCert: `http://timestamp.digicert.com`
-- GlobalSign: `http://timestamp.globalsign.com/tsa/r6advanced1`
-- Sectigo: `http://timestamp.sectigo.com`
-
-### Verification API
-```ruby
-# Verify a signed artifact
-result = EasyCodeSign.verify('path/to/signed.gem')
-
-result.valid?              # Overall validity
-result.signature_valid?    # Cryptographic signature OK
-result.certificate_valid?  # Certificate chain valid
-result.timestamp_valid?    # Timestamp present and valid
-result.trusted?            # Signing cert chains to trusted root
-result.signer              # Certificate info of signer
-result.timestamp           # Timestamp info (if present)
-result.errors              # Array of validation errors
-result.warnings            # Array of warnings (e.g., expiring cert)
-```
-
-### Provider Pattern
-Extensible design allowing future providers:
-```ruby
-EasyCodeSign.configure do |config|
-  config.provider = :safenet
-  config.pkcs11_library = '/path/to/library'
-end
-```
-
-## Dependencies
-
-- `pkcs11` - PKCS#11 bindings
-- `openssl` - Certificate/signature operations (stdlib)
-- `zip` or `rubyzip` - ZIP manipulation
-- `net-http` - TSA communication (stdlib)
-- `thor` - CLI (optional)
-
-## Development Guidelines
-
-- Ruby 3.0+ required
-- Use RSpec for testing
-- Mock PKCS#11 operations in tests (SoftHSM2 for integration tests)
-- Follow standard Ruby style (RuboCop)
-
-## Security Considerations
-
-- Never log or store PINs
-- Clear sensitive memory when possible
-- Support secure PIN entry callbacks
-- Validate certificate chains before signing
-- Validate TSA responses cryptographically
-- Use HTTPS for TSA communication when available
-- Check certificate revocation status during verification
+1. Create `lib/easy_code_sign/signable/new_type.rb` inheriting `Signable::Base`
+2. Implement: `prepare_for_signing`, `content_to_sign`, `apply_signature`, `extract_signature`, `signed?`
+3. Register the extension in `EasyCodeSign.signable_for` (in `lib/easy_code_sign.rb`)
+4. Add verification support in `Verifier`
+5. Add CLI options if needed in `cli.rb`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **PDF Document Signing**
+  - Sign PDF documents (.pdf) with PKCS#7 digital signatures
+  - Visible signature annotations with customizable position (top-left, top-right, bottom-left, bottom-right)
+  - Signature metadata (reason, location, contact info)
+  - Page selection for signature placement
+  - RFC 3161 timestamp embedding in PDF signatures
+  - ByteRange-based signing for PDF incremental updates
+
+- **PDF Verification**
+  - Verify signed PDF documents
+  - ByteRange integrity checking
+  - Extract and display PDF signature metadata
+
+- **CLI Enhancements for PDF**
+  - `--visible-signature` - Add visible signature annotation
+  - `--signature-page` - Select page for signature
+  - `--signature-position` - Position preset (top_left, top_right, bottom_left, bottom_right)
+  - `--signature-reason` - Reason for signing
+  - `--signature-location` - Signing location
+
+### Dependencies
+
+- Added HexaPDF (~> 1.0) for PDF manipulation and signing
+
 ## [0.1.0] - 2025-01-06
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     easy_code_sign (0.1.0)
       base64 (~> 0.2)
+      hexapdf (~> 1.0)
       pkcs11 (~> 0.3)
       rubyzip (~> 2.3)
       thor (~> 1.3)
@@ -12,9 +13,16 @@ GEM
   specs:
     ast (2.4.3)
     base64 (0.3.0)
+    cmdparse (3.0.7)
     date (3.5.1)
     diff-lcs (1.6.2)
     erb (6.0.1)
+    geom2d (0.4.1)
+    hexapdf (1.5.0)
+      cmdparse (~> 3.0, >= 3.0.3)
+      geom2d (~> 0.4, >= 0.4.1)
+      openssl (>= 2.2.1)
+      strscan (>= 3.1.2)
     io-console (0.8.2)
     irb (1.16.0)
       pp (>= 0.6.0)
@@ -24,6 +32,7 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     minitest (5.27.0)
+    openssl (4.0.0)
     parallel (1.27.0)
     parser (3.3.10.0)
       ast (~> 2.4.1)
@@ -76,6 +85,7 @@ GEM
     ruby-progressbar (1.13.0)
     rubyzip (2.4.1)
     stringio (3.2.0)
+    strscan (3.1.7)
     thor (1.4.0)
     tsort (0.2.0)
     unicode-display_width (3.2.0)
@@ -97,16 +107,20 @@ DEPENDENCIES
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  cmdparse (3.0.7) sha256=f7c5cace10bec6abf853370ae095e4b97a84ed9d847b3fb38f41cc4fbc950739
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   easy_code_sign (0.1.0)
   erb (6.0.1) sha256=28ecdd99c5472aebd5674d6061e3c6b0a45c049578b071e5a52c2a7f13c197e5
+  geom2d (0.4.1) sha256=ea0998ea90c4f2752e24fe13d85a4f89bee689d151316140ebcc6369bf634ed9
+  hexapdf (1.5.0) sha256=05ab16c894ef59a8b65fdc5f5eeca941d7c0fc85a02c81728c3db9321d8e2438
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.16.0) sha256=2abe56c9ac947cdcb2f150572904ba798c1e93c890c256f8429981a7675b0806
   json (2.18.0) sha256=b10506aee4183f5cf49e0efc48073d7b75843ce3782c68dbeb763351c08fd505
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
+  openssl (4.0.0) sha256=185711ed93d4e9c9a9db6efea7edb202dfe04f7d3692fbab988e3d84e498ee91
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.0) sha256=ce3587fa5cc55a88c4ba5b2b37621b3329aadf5728f9eafa36bbd121462aabd6
   pkcs11 (0.3.4) sha256=59823d195f13f5e69973cbc01b82fc9c436bfa13bf5fba82cec443936a527367
@@ -130,6 +144,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
+  strscan (3.1.7) sha256=5f76462b94a3ea50b44973225b7d75b2cb96d4e1bee9ef1319b99ca117b72c8c
   thor (1.4.0) sha256=8763e822ccb0f1d7bee88cde131b19a65606657b847cc7b7b4b82e772bcd8a3d
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # EasyCodeSign
 
-A Ruby gem for signing and verifying Ruby gems and ZIP files using hardware security tokens (HSM/smart cards). Currently supports SafeNet eToken with plans for additional providers.
+A Ruby gem for signing and verifying Ruby gems, ZIP files, and PDF documents using hardware security tokens (HSM/smart cards). Currently supports SafeNet eToken with plans for additional providers.
 
 ## Features
 
 - **Sign Ruby gems** (.gem) - Creates PKCS#7 signatures compatible with `gem cert`
 - **Sign ZIP archives** (.zip, .jar, .apk, .war, .ear) - JAR-style signing with META-INF manifest
+- **Sign PDF documents** (.pdf) - Digital signatures with optional visible annotations
 - **Hardware token support** - SafeNet eToken via PKCS#11 (extensible for other HSMs)
 - **RFC 3161 timestamping** - Proves signature existed at a specific time
 - **Full verification** - Signature, certificate chain, trust, and timestamp validation
@@ -48,6 +49,22 @@ easysign sign archive.zip --output signed_archive.zip
 
 # Use specific PKCS#11 library
 easysign sign my_gem.gem --library /path/to/libeToken.dylib
+```
+
+### Sign a PDF
+
+```bash
+# Basic PDF signing (invisible signature)
+easysign sign document.pdf
+
+# PDF with visible signature annotation
+easysign sign document.pdf --visible-signature --signature-position bottom-right
+
+# PDF with timestamp and metadata
+easysign sign document.pdf -t --visible-signature --signature-reason "Approved" --signature-location "New York"
+
+# PDF signing on specific page
+easysign sign document.pdf --visible-signature --signature-page 2
 ```
 
 > **Security Note:** The PIN is always entered interactively via a secure prompt.

--- a/easy_code_sign.gemspec
+++ b/easy_code_sign.gemspec
@@ -8,9 +8,10 @@ Gem::Specification.new do |spec|
   spec.authors = ["michail"]
   spec.email = ["mpantel@aegean.gr"]
 
-  spec.summary = "Sign and verify Ruby gems and ZIP files using hardware security tokens"
+  spec.summary = "Sign and verify Ruby gems, ZIP files, and PDFs using hardware security tokens"
   spec.description = "A Ruby gem for code signing operations using hardware tokens (HSM/smart cards) " \
-                     "via PKCS#11. Supports SafeNet eToken, RFC 3161 timestamping, and signature verification."
+                     "via PKCS#11. Supports SafeNet eToken, RFC 3161 timestamping, PDF visible signatures, " \
+                     "and signature verification."
   spec.homepage = "https://github.com/mpantel/easy_code_sign"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.2.0"
@@ -33,6 +34,7 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies
   spec.add_dependency "base64", "~> 0.2"
+  spec.add_dependency "hexapdf", "~> 1.0"
   spec.add_dependency "pkcs11", "~> 0.3"
   spec.add_dependency "rubyzip", "~> 2.3"
   spec.add_dependency "thor", "~> 1.3"

--- a/lib/easy_code_sign.rb
+++ b/lib/easy_code_sign.rb
@@ -125,9 +125,9 @@ module EasyCodeSign
     #   result = EasyCodeSign.finalize_pdf(request, raw_signature)
     #   result.file_path #=> "document_prepared.pdf"
     #
-    def finalize_pdf(deferred_request, raw_signature)
+    def finalize_pdf(deferred_request, raw_signature, **options)
       signer = Signer.new
-      signer.finalize_pdf(deferred_request, raw_signature)
+      signer.finalize_pdf(deferred_request, raw_signature, **options)
     end
 
     # Create a verifier instance for batch operations

--- a/lib/easy_code_sign.rb
+++ b/lib/easy_code_sign.rb
@@ -9,6 +9,9 @@ require_relative "easy_code_sign/providers/safenet"
 require_relative "easy_code_sign/signable/base"
 require_relative "easy_code_sign/signable/gem_file"
 require_relative "easy_code_sign/signable/zip_file"
+require_relative "easy_code_sign/signable/pdf_file"
+require_relative "easy_code_sign/pdf/timestamp_handler"
+require_relative "easy_code_sign/pdf/appearance_builder"
 require_relative "easy_code_sign/timestamp/request"
 require_relative "easy_code_sign/timestamp/response"
 require_relative "easy_code_sign/timestamp/client"
@@ -120,6 +123,8 @@ module EasyCodeSign
         Signable::GemFile.new(file_path, **options)
       when ".zip", ".jar", ".apk", ".war", ".ear"
         Signable::ZipFile.new(file_path, **options)
+      when ".pdf"
+        Signable::PdfFile.new(file_path, **options)
       else
         raise InvalidFileError, "Unsupported file type: #{extension}"
       end

--- a/lib/easy_code_sign.rb
+++ b/lib/easy_code_sign.rb
@@ -20,6 +20,7 @@ require_relative "easy_code_sign/verification/result"
 require_relative "easy_code_sign/verification/trust_store"
 require_relative "easy_code_sign/verification/certificate_chain"
 require_relative "easy_code_sign/verification/signature_checker"
+require_relative "easy_code_sign/deferred_signing_request"
 require_relative "easy_code_sign/signer"
 require_relative "easy_code_sign/verifier"
 
@@ -91,6 +92,42 @@ module EasyCodeSign
     def verify(file_path, check_timestamp: true, trust_store: nil)
       verifier = Verifier.new(trust_store: trust_store)
       verifier.verify(file_path, check_timestamp: check_timestamp)
+    end
+
+    # Phase 1 of deferred PDF signing.
+    # Prepares a PDF with placeholder signature and returns a DeferredSigningRequest
+    # containing the digest to be signed by an external signer (Fortify, WebCrypto, etc.).
+    #
+    # @param file_path [String] path to the PDF
+    # @param pin [String, nil] PIN for hardware token (needed for certificate retrieval)
+    # @param digest_algorithm [String] "sha256", "sha384", or "sha512"
+    # @param timestamp [Boolean] whether to reserve timestamp space
+    # @return [DeferredSigningRequest]
+    #
+    # @example
+    #   request = EasyCodeSign.prepare_pdf("document.pdf", pin: "1234")
+    #   request.digest_base64 #=> "abc123..."  (send to external signer)
+    #
+    def prepare_pdf(file_path, pin: nil, digest_algorithm: "sha256", timestamp: false, **extra_options)
+      signer = Signer.new
+      signer.prepare_pdf(file_path, pin: pin, digest_algorithm: digest_algorithm,
+                                    timestamp: timestamp, **extra_options)
+    end
+
+    # Phase 2 of deferred PDF signing.
+    # Embeds an externally-produced raw signature into the prepared PDF.
+    #
+    # @param deferred_request [DeferredSigningRequest] from prepare_pdf
+    # @param raw_signature [String] raw signature bytes from external signer
+    # @return [SigningResult]
+    #
+    # @example
+    #   result = EasyCodeSign.finalize_pdf(request, raw_signature)
+    #   result.file_path #=> "document_prepared.pdf"
+    #
+    def finalize_pdf(deferred_request, raw_signature)
+      signer = Signer.new
+      signer.finalize_pdf(deferred_request, raw_signature)
     end
 
     # Create a verifier instance for batch operations

--- a/lib/easy_code_sign/cli.rb
+++ b/lib/easy_code_sign/cli.rb
@@ -20,16 +20,18 @@ module EasyCodeSign
       true
     end
 
-    desc "sign FILE", "Sign a file (gem or zip) using hardware token"
+    desc "sign FILE", "Sign a file (gem, zip, or PDF) using hardware token"
     long_desc <<~DESC
       Sign a file using a hardware security token (HSM/smart card).
 
       Supported file types:
         - Ruby gems (.gem)
         - ZIP archives (.zip, .jar, .apk, .war, .ear)
+        - PDF documents (.pdf)
 
       The signature is embedded in the file. For gems, this creates
-      PKCS#7 detached signatures compatible with `gem cert`.
+      PKCS#7 detached signatures. For PDFs, use --visible-signature
+      to add a visible signature annotation.
     DESC
     option :output, type: :string, aliases: "-o", desc: "Output file path (default: overwrite input)"
     option :timestamp, type: :boolean, default: false, aliases: "-t", desc: "Add RFC 3161 timestamp"
@@ -38,6 +40,12 @@ module EasyCodeSign
     option :provider, type: :string, default: "safenet", desc: "Token provider (safenet)"
     option :library, type: :string, desc: "Path to PKCS#11 library"
     option :slot, type: :numeric, default: 0, desc: "Token slot index"
+    # PDF-specific options
+    option :visible_signature, type: :boolean, default: false, desc: "[PDF] Add visible signature annotation"
+    option :signature_page, type: :numeric, default: 1, desc: "[PDF] Page number for visible signature"
+    option :signature_position, type: :string, default: "bottom_right", desc: "[PDF] Position (top_left, top_right, bottom_left, bottom_right)"
+    option :signature_reason, type: :string, desc: "[PDF] Reason for signing"
+    option :signature_location, type: :string, desc: "[PDF] Location of signing"
     def sign(file)
       configure_from_options
 
@@ -46,13 +54,24 @@ module EasyCodeSign
 
       say "Signing #{file}...", :cyan unless options[:quiet]
 
-      result = EasyCodeSign.sign(
-        file,
+      # Build signing options, including PDF-specific ones
+      sign_opts = {
         pin: pin,
         output_path: options[:output],
         timestamp: options[:timestamp],
         algorithm: algorithm
-      )
+      }
+
+      # Add PDF options if present
+      if File.extname(file).downcase == ".pdf"
+        sign_opts[:visible_signature] = options[:visible_signature]
+        sign_opts[:signature_page] = options[:signature_page]
+        sign_opts[:signature_position] = options[:signature_position]&.to_sym
+        sign_opts[:signature_reason] = options[:signature_reason]
+        sign_opts[:signature_location] = options[:signature_location]
+      end
+
+      result = EasyCodeSign.sign(file, **sign_opts)
 
       if options[:verbose]
         say "\nSigning complete:", :green
@@ -178,6 +197,8 @@ module EasyCodeSign
         display_gem_signature_info(signature)
       when Signable::ZipFile
         display_zip_signature_info(signature)
+      when Signable::PdfFile
+        display_pdf_signature_info(signature)
       end
     rescue EasyCodeSign::Error => e
       say_error "Failed to read signature: #{e.message}"
@@ -276,6 +297,17 @@ module EasyCodeSign
       say "  - MANIFEST.MF: #{signature[:manifest] ? 'present' : 'missing'}"
       say "  - CERT.SF: #{signature[:signature_file] ? 'present' : 'missing'}"
       say "  - CERT.RSA: #{signature[:signature_block] ? 'present' : 'missing'}"
+    end
+
+    def display_pdf_signature_info(signature)
+      say "PDF Signature:"
+      say "  - SubFilter: #{signature[:sub_filter] || 'unknown'}"
+      say "  - ByteRange: #{signature[:byte_range]&.inspect || 'unknown'}"
+      say "  - Name: #{signature[:name]}" if signature[:name]
+      say "  - Reason: #{signature[:reason]}" if signature[:reason]
+      say "  - Location: #{signature[:location]}" if signature[:location]
+      say "  - Signing Time: #{signature[:signing_time]}" if signature[:signing_time]
+      say "  - Contact: #{signature[:contact_info]}" if signature[:contact_info]
     end
 
     def say_error(message)

--- a/lib/easy_code_sign/cli.rb
+++ b/lib/easy_code_sign/cli.rb
@@ -243,6 +243,8 @@ module EasyCodeSign
       SIGNATURE_FILE should contain the raw signature bytes (binary DER) produced
       by signing the digest from the prepare-pdf step.
     DESC
+    option :timestamp, type: :boolean, default: false, aliases: "-t", desc: "Add RFC 3161 timestamp"
+    option :tsa, type: :string, desc: "Timestamp authority URL"
     option :request_json, type: :string, desc: "Path to request JSON (default: PREPARED_PDF.json)"
     def finalize_pdf(prepared_pdf, signature_file)
       require "json"
@@ -259,19 +261,22 @@ module EasyCodeSign
         exit 1
       end
 
+      configure_from_options
+
       say "Finalizing deferred signature on #{prepared_pdf}...", :cyan unless options[:quiet]
 
       request_hash = JSON.parse(File.read(request_path))
       request = EasyCodeSign::DeferredSigningRequest.from_h(request_hash)
       raw_signature = File.binread(signature_file)
 
-      result = EasyCodeSign.finalize_pdf(request, raw_signature)
+      result = EasyCodeSign.finalize_pdf(request, raw_signature, timestamp: options[:timestamp])
 
       if options[:verbose]
         say "\nSigning complete:", :green
         say "  File: #{result.file_path}"
         say "  Signer: #{result.signer_name}"
         say "  Algorithm: #{result.algorithm}"
+        say "  Timestamped: #{result.timestamped? ? 'Yes' : 'No'}"
         say "  Signed at: #{result.signed_at}"
       else
         say "Signed: #{result.file_path}", :green unless options[:quiet]

--- a/lib/easy_code_sign/cli.rb
+++ b/lib/easy_code_sign/cli.rb
@@ -175,6 +175,112 @@ module EasyCodeSign
       exit 1
     end
 
+    desc "prepare-pdf FILE", "Prepare a PDF for deferred (two-phase) signing"
+    long_desc <<~DESC
+      Phase 1 of deferred PDF signing.
+
+      Prepares the PDF with a placeholder signature and outputs the digest
+      that must be signed by an external signer (Fortify, WebCrypto, remote HSM).
+
+      The prepared PDF and a JSON request file are written alongside the input.
+      Send the digest to your external signing service, then use finalize-pdf
+      to embed the real signature.
+    DESC
+    option :algorithm, type: :string, default: "sha256", desc: "Hash algorithm (sha256, sha384, sha512)"
+    option :timestamp, type: :boolean, default: false, aliases: "-t", desc: "Reserve space for timestamp"
+    option :provider, type: :string, default: "safenet", desc: "Token provider (safenet)"
+    option :library, type: :string, desc: "Path to PKCS#11 library"
+    option :slot, type: :numeric, default: 0, desc: "Token slot index"
+    option :json, type: :boolean, default: false, desc: "Output result as JSON"
+    option :signature_reason, type: :string, desc: "[PDF] Reason for signing"
+    option :signature_location, type: :string, desc: "[PDF] Location of signing"
+    def prepare_pdf(file)
+      configure_from_options
+
+      pin = prompt_for_pin
+
+      say "Preparing #{file} for deferred signing...", :cyan unless options[:quiet]
+
+      prepare_opts = {
+        pin: pin,
+        digest_algorithm: options[:algorithm],
+        timestamp: options[:timestamp],
+        signature_reason: options[:signature_reason],
+        signature_location: options[:signature_location]
+      }.compact
+
+      request = EasyCodeSign.prepare_pdf(file, **prepare_opts)
+
+      # Write request JSON for later use
+      request_path = "#{request.prepared_pdf_path}.json"
+      require "json"
+      File.write(request_path, JSON.pretty_generate(request.to_h))
+
+      if options[:json]
+        say JSON.pretty_generate(request.to_h)
+      else
+        say "Prepared: #{request.prepared_pdf_path}", :green unless options[:quiet]
+        say "Request saved: #{request_path}" unless options[:quiet]
+        say "" unless options[:quiet]
+        say "Digest (hex):    #{request.digest_hex}" unless options[:quiet]
+        say "Digest (base64): #{request.digest_base64}" unless options[:quiet]
+        say "" unless options[:quiet]
+        say "Sign the digest externally, then run:", :cyan unless options[:quiet]
+        say "  easysign finalize-pdf #{request.prepared_pdf_path} SIGNATURE_FILE" unless options[:quiet]
+      end
+    rescue EasyCodeSign::Error => e
+      say_error "Prepare failed: #{e.message}"
+      exit 1
+    end
+
+    desc "finalize-pdf PREPARED_PDF SIGNATURE_FILE", "Finalize a deferred PDF signature"
+    long_desc <<~DESC
+      Phase 2 of deferred PDF signing.
+
+      Reads the prepared PDF and its accompanying .json request file, then
+      embeds the raw signature from SIGNATURE_FILE into the PDF.
+
+      SIGNATURE_FILE should contain the raw signature bytes (binary DER) produced
+      by signing the digest from the prepare-pdf step.
+    DESC
+    option :request_json, type: :string, desc: "Path to request JSON (default: PREPARED_PDF.json)"
+    def finalize_pdf(prepared_pdf, signature_file)
+      require "json"
+
+      request_path = options[:request_json] || "#{prepared_pdf}.json"
+      unless File.exist?(request_path)
+        say_error "Request file not found: #{request_path}"
+        say_error "Specify --request-json or ensure the .json file from prepare-pdf exists"
+        exit 1
+      end
+
+      unless File.exist?(signature_file)
+        say_error "Signature file not found: #{signature_file}"
+        exit 1
+      end
+
+      say "Finalizing deferred signature on #{prepared_pdf}...", :cyan unless options[:quiet]
+
+      request_hash = JSON.parse(File.read(request_path))
+      request = EasyCodeSign::DeferredSigningRequest.from_h(request_hash)
+      raw_signature = File.binread(signature_file)
+
+      result = EasyCodeSign.finalize_pdf(request, raw_signature)
+
+      if options[:verbose]
+        say "\nSigning complete:", :green
+        say "  File: #{result.file_path}"
+        say "  Signer: #{result.signer_name}"
+        say "  Algorithm: #{result.algorithm}"
+        say "  Signed at: #{result.signed_at}"
+      else
+        say "Signed: #{result.file_path}", :green unless options[:quiet]
+      end
+    rescue EasyCodeSign::Error => e
+      say_error "Finalize failed: #{e.message}"
+      exit 1
+    end
+
     desc "info FILE", "Show signature information for a signed file"
     long_desc <<~DESC
       Display detailed information about a file's signature without

--- a/lib/easy_code_sign/configuration.rb
+++ b/lib/easy_code_sign/configuration.rb
@@ -59,7 +59,7 @@ module EasyCodeSign
       @provider = :safenet
       @pkcs11_library = default_pkcs11_library
       @slot_index = 0
-      @timestamp_authority = nil
+      @timestamp_authority = ENV["EASYSIGN_TSA_URL"]
       @timestamp_hash_algorithm = :sha256
       @require_timestamp = false
       @trust_store_path = nil

--- a/lib/easy_code_sign/deferred_signing_request.rb
+++ b/lib/easy_code_sign/deferred_signing_request.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "base64"
+require "time"
+
+module EasyCodeSign
+  # Serializable data object returned by Phase 1 of deferred PDF signing.
+  #
+  # Contains the digest computed from the PDF's ByteRange content, along with
+  # all metadata needed to finalize the signature in Phase 2.
+  #
+  # @example Prepare and serialize
+  #   request = EasyCodeSign.prepare_pdf("doc.pdf", pin: "1234")
+  #   json = request.to_h.to_json
+  #
+  # @example Deserialize and finalize
+  #   restored = DeferredSigningRequest.from_h(JSON.parse(json))
+  #   EasyCodeSign.finalize_pdf(restored, raw_signature)
+  #
+  class DeferredSigningRequest
+    attr_reader :digest,
+                :digest_algorithm,
+                :prepared_pdf_path,
+                :byte_range,
+                :certificate,
+                :certificate_chain,
+                :estimated_size,
+                :signing_time,
+                :created_at
+
+    def initialize(digest:, digest_algorithm:, prepared_pdf_path:, byte_range:,
+                   certificate:, certificate_chain:, estimated_size:,
+                   signing_time:, created_at: Time.now)
+      @digest = digest
+      @digest_algorithm = digest_algorithm.to_sym
+      @prepared_pdf_path = prepared_pdf_path
+      @byte_range = byte_range
+      @certificate = certificate
+      @certificate_chain = certificate_chain
+      @estimated_size = estimated_size
+      @signing_time = signing_time
+      @created_at = created_at
+    end
+
+    # Hex-encoded digest for display and CLI output
+    # @return [String]
+    def digest_hex
+      digest.unpack1("H*")
+    end
+
+    # Base64-encoded digest for WebCrypto / Fortify consumption
+    # @return [String]
+    def digest_base64
+      Base64.strict_encode64(digest)
+    end
+
+    # Serialize to a Hash suitable for JSON transport.
+    # Binary fields are Base64-encoded, certificates are PEM-encoded.
+    # @return [Hash]
+    def to_h
+      {
+        "digest" => digest_base64,
+        "digest_algorithm" => digest_algorithm.to_s,
+        "prepared_pdf_path" => prepared_pdf_path,
+        "byte_range" => byte_range,
+        "certificate" => certificate.to_pem,
+        "certificate_chain" => certificate_chain.map(&:to_pem),
+        "estimated_size" => estimated_size,
+        "signing_time" => signing_time.iso8601,
+        "created_at" => created_at.iso8601
+      }
+    end
+
+    # Deserialize from a Hash (as produced by #to_h / JSON.parse).
+    # @param hash [Hash] serialized request
+    # @return [DeferredSigningRequest]
+    def self.from_h(hash)
+      new(
+        digest: Base64.strict_decode64(hash["digest"]),
+        digest_algorithm: hash["digest_algorithm"].to_sym,
+        prepared_pdf_path: hash["prepared_pdf_path"],
+        byte_range: hash["byte_range"],
+        certificate: OpenSSL::X509::Certificate.new(hash["certificate"]),
+        certificate_chain: hash["certificate_chain"].map { |pem| OpenSSL::X509::Certificate.new(pem) },
+        estimated_size: hash["estimated_size"],
+        signing_time: Time.parse(hash["signing_time"]),
+        created_at: Time.parse(hash["created_at"])
+      )
+    end
+  end
+end

--- a/lib/easy_code_sign/deferred_signing_request.rb
+++ b/lib/easy_code_sign/deferred_signing_request.rb
@@ -26,11 +26,12 @@ module EasyCodeSign
                 :certificate_chain,
                 :estimated_size,
                 :signing_time,
-                :created_at
+                :created_at,
+                :signed_attributes_data
 
     def initialize(digest:, digest_algorithm:, prepared_pdf_path:, byte_range:,
                    certificate:, certificate_chain:, estimated_size:,
-                   signing_time:, created_at: Time.now)
+                   signing_time:, created_at: Time.now, signed_attributes_data: nil)
       @digest = digest
       @digest_algorithm = digest_algorithm.to_sym
       @prepared_pdf_path = prepared_pdf_path
@@ -40,6 +41,7 @@ module EasyCodeSign
       @estimated_size = estimated_size
       @signing_time = signing_time
       @created_at = created_at
+      @signed_attributes_data = signed_attributes_data
     end
 
     # Hex-encoded digest for display and CLI output
@@ -54,11 +56,19 @@ module EasyCodeSign
       Base64.strict_encode64(digest)
     end
 
+    # Base64-encoded signed attributes DER for WebCrypto hash-and-sign.
+    # Use this instead of digest_base64 when the signer hashes internally
+    # (e.g. crypto.subtle.sign("RSASSA-PKCS1-v1_5", key, data)).
+    # @return [String, nil]
+    def signed_attributes_base64
+      signed_attributes_data && Base64.strict_encode64(signed_attributes_data)
+    end
+
     # Serialize to a Hash suitable for JSON transport.
     # Binary fields are Base64-encoded, certificates are PEM-encoded.
     # @return [Hash]
     def to_h
-      {
+      h = {
         "digest" => digest_base64,
         "digest_algorithm" => digest_algorithm.to_s,
         "prepared_pdf_path" => prepared_pdf_path,
@@ -69,6 +79,8 @@ module EasyCodeSign
         "signing_time" => signing_time.iso8601,
         "created_at" => created_at.iso8601
       }
+      h["signed_attributes_data"] = signed_attributes_base64 if signed_attributes_data
+      h
     end
 
     # Deserialize from a Hash (as produced by #to_h / JSON.parse).
@@ -84,7 +96,8 @@ module EasyCodeSign
         certificate_chain: hash["certificate_chain"].map { |pem| OpenSSL::X509::Certificate.new(pem) },
         estimated_size: hash["estimated_size"],
         signing_time: Time.parse(hash["signing_time"]),
-        created_at: Time.parse(hash["created_at"])
+        created_at: Time.parse(hash["created_at"]),
+        signed_attributes_data: hash["signed_attributes_data"] && Base64.strict_decode64(hash["signed_attributes_data"])
       )
     end
   end

--- a/lib/easy_code_sign/errors.rb
+++ b/lib/easy_code_sign/errors.rb
@@ -107,4 +107,7 @@ module EasyCodeSign
 
   # Raised when ByteRange calculation or verification fails
   class ByteRangeError < PdfError; end
+
+  # Raised when deferred (two-phase) PDF signing fails
+  class DeferredSigningError < PdfError; end
 end

--- a/lib/easy_code_sign/errors.rb
+++ b/lib/easy_code_sign/errors.rb
@@ -95,4 +95,16 @@ module EasyCodeSign
 
   # Raised when a required timestamp is missing
   class MissingTimestampError < TimestampError; end
+
+  # Base class for PDF-related errors
+  class PdfError < SigningError; end
+
+  # Raised when the PDF file is invalid or cannot be parsed
+  class InvalidPdfError < PdfError; end
+
+  # Raised when PDF signature operations fail
+  class PdfSignatureError < PdfError; end
+
+  # Raised when ByteRange calculation or verification fails
+  class ByteRangeError < PdfError; end
 end

--- a/lib/easy_code_sign/pdf/appearance_builder.rb
+++ b/lib/easy_code_sign/pdf/appearance_builder.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module EasyCodeSign
+  module Pdf
+    # Builds visible signature appearance for PDF signatures
+    #
+    # Creates an appearance stream that displays signature information
+    # in the PDF document (signer name, date, reason, etc.)
+    #
+    class AppearanceBuilder
+      POSITIONS = {
+        top_left: ->(box) { [36, box.height - 36 - 50, 236, box.height - 36] },
+        top_right: ->(box) { [box.width - 236, box.height - 36 - 50, box.width - 36, box.height - 36] },
+        bottom_left: ->(box) { [36, 36, 236, 86] },
+        bottom_right: ->(box) { [box.width - 236, 36, box.width - 36, 86] }
+      }.freeze
+
+      def initialize(document, config, certificate)
+        @document = document
+        @config = config
+        @certificate = certificate
+      end
+
+      # Build appearance stream for visible signature
+      # @param widget [HexaPDF::Type::Annotations::Widget] the signature widget
+      # @return [void]
+      def build_appearance(widget)
+        rect = widget[:Rect].value
+        width = rect[2] - rect[0]
+        height = rect[3] - rect[1]
+
+        # Create appearance form XObject
+        form = @document.add({ Type: :XObject, Subtype: :Form, BBox: [0, 0, width, height] })
+        canvas = form.canvas
+
+        # Draw border
+        canvas.stroke_color(0, 0, 0)
+        canvas.line_width(1)
+        canvas.rectangle(0.5, 0.5, width - 1, height - 1)
+        canvas.stroke
+
+        # Draw text content
+        draw_signature_text(canvas, width, height)
+
+        # Set as widget's normal appearance
+        widget[:AP] = { N: form }
+      end
+
+      # Calculate signature rectangle for a given position
+      # @param page [HexaPDF::Type::Page] the page
+      # @param position [Symbol] position preset
+      # @return [Array<Numeric>] rectangle coordinates [x1, y1, x2, y2]
+      def self.calculate_rect(page, position, custom_rect: nil)
+        return custom_rect if custom_rect
+
+        box = page.box(:media)
+        calculator = POSITIONS[position.to_sym] || POSITIONS[:bottom_right]
+        calculator.call(box)
+      end
+
+      private
+
+      def draw_signature_text(canvas, width, height)
+        canvas.font("Helvetica", size: 8)
+        canvas.fill_color(0, 0, 0)
+
+        y_offset = height - 12
+        x_offset = 5
+
+        # Signer name
+        signer = extract_signer_name
+        canvas.text("Digitally signed by:", at: [x_offset, y_offset])
+        y_offset -= 10
+        canvas.text(signer, at: [x_offset, y_offset])
+        y_offset -= 12
+
+        # Reason (if provided)
+        if @config[:reason]
+          canvas.text("Reason: #{@config[:reason]}", at: [x_offset, y_offset])
+          y_offset -= 10
+        end
+
+        # Location (if provided)
+        if @config[:location]
+          canvas.text("Location: #{@config[:location]}", at: [x_offset, y_offset])
+          y_offset -= 10
+        end
+
+        # Date
+        canvas.text("Date: #{Time.now.strftime('%Y-%m-%d %H:%M:%S %Z')}", at: [x_offset, y_offset])
+      end
+
+      def extract_signer_name
+        # Try to extract CN from certificate subject
+        subject = @certificate.subject.to_a
+        cn = subject.find { |name, _, _| name == "CN" }
+        return cn[1] if cn
+
+        # Fallback to full subject
+        @certificate.subject.to_s
+      end
+    end
+  end
+end

--- a/lib/easy_code_sign/pdf/timestamp_handler.rb
+++ b/lib/easy_code_sign/pdf/timestamp_handler.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module EasyCodeSign
+  module Pdf
+    # Handles embedding RFC 3161 timestamps in PDF signatures
+    #
+    # PDF signatures can include timestamps in the unsigned attributes of the
+    # CMS SignedData structure (PAdES-B compliance).
+    #
+    class TimestampHandler
+      attr_reader :timestamp_token
+
+      def initialize(timestamp_token)
+        @timestamp_token = timestamp_token
+      end
+
+      # Called by HexaPDF to embed timestamp in signature
+      # @param signature_value [String] the signature value to timestamp
+      # @return [String] timestamp token DER bytes
+      def timestamp(signature_value)
+        if @timestamp_token
+          @timestamp_token.token
+        else
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/easy_code_sign/pdf/timestamp_handler.rb
+++ b/lib/easy_code_sign/pdf/timestamp_handler.rb
@@ -2,27 +2,29 @@
 
 module EasyCodeSign
   module Pdf
-    # Handles embedding RFC 3161 timestamps in PDF signatures
+    # Adapts a pre-fetched timestamp token for HexaPDF's SignedDataCreator.
     #
-    # PDF signatures can include timestamps in the unsigned attributes of the
-    # CMS SignedData structure (PAdES-B compliance).
+    # HexaPDF's SignedDataCreator calls `timestamp_handler.sign(io, byte_range)`
+    # and embeds the return value as the id-aa-timeStampToken unsigned attribute.
+    # This handler returns the DER bytes of an already-obtained token rather than
+    # making a live TSA request.
+    #
+    # Supports both eager (TimestampToken) and lazy (Proc) modes:
+    #   - Eager: TimestampHandler.new(token)       — token already available
+    #   - Lazy:  TimestampHandler.new(-> { token }) — token resolved at sign time
     #
     class TimestampHandler
-      attr_reader :timestamp_token
-
       def initialize(timestamp_token)
         @timestamp_token = timestamp_token
       end
 
-      # Called by HexaPDF to embed timestamp in signature
-      # @param signature_value [String] the signature value to timestamp
-      # @return [String] timestamp token DER bytes
-      def timestamp(signature_value)
-        if @timestamp_token
-          @timestamp_token.token
-        else
-          nil
-        end
+      # Called by HexaPDF's SignedDataCreator#create_unsigned_attrs
+      # @param _io [IO] ignored — we already have the token
+      # @param _byte_range [Array] ignored
+      # @return [String, nil] DER-encoded timestamp token
+      def sign(_io, _byte_range)
+        token = @timestamp_token.respond_to?(:call) ? @timestamp_token.call : @timestamp_token
+        token&.token_der
       end
     end
   end

--- a/lib/easy_code_sign/signable/pdf_file.rb
+++ b/lib/easy_code_sign/signable/pdf_file.rb
@@ -1,0 +1,322 @@
+# frozen_string_literal: true
+
+require "hexapdf"
+
+module EasyCodeSign
+  module Signable
+    # Handler for signing PDF files
+    #
+    # PDF signatures use a ByteRange approach where specific byte ranges are signed,
+    # excluding the signature field itself. This allows incremental updates.
+    #
+    # @example Sign a PDF
+    #   pdf = PdfFile.new("document.pdf")
+    #   pdf.prepare_for_signing
+    #   content = pdf.content_to_sign
+    #   # ... sign content with HSM ...
+    #   pdf.apply_signature(signature, certificate_chain)
+    #
+    class PdfFile < Base
+      SUPPORTED_EXTENSIONS = %w[.pdf].freeze
+
+      # Signature appearance configuration
+      attr_reader :signature_config
+
+      def initialize(file_path, **options)
+        super
+        validate_pdf!
+        @signature_config = build_signature_config(options)
+        @document = nil
+        @signature_field = nil
+        @prepared_data = nil
+      end
+
+      # Prepare PDF for signing by creating signature field and calculating ByteRange
+      # @return [void]
+      def prepare_for_signing
+        @document = HexaPDF::Document.open(file_path)
+
+        # Create signature field
+        @signature_field = create_signature_field
+
+        # Set up the signing handler that will be called by HexaPDF
+        @prepared_data = {
+          document: @document,
+          signature_field: @signature_field
+        }
+      end
+
+      # Get content to sign (hash of ByteRange content)
+      # HexaPDF calculates this during the signing process
+      # @return [String] placeholder - actual content determined during apply_signature
+      def content_to_sign
+        prepare_for_signing if @prepared_data.nil?
+
+        # For PDF signing, the actual content to sign is determined by ByteRange
+        # during the signature embedding process. We return a placeholder here
+        # and handle the actual signing in apply_signature via a custom handler.
+        #
+        # The real signing happens through ExternalSigningHandler which receives
+        # the ByteRange content from HexaPDF.
+        "PDF_SIGNING_PLACEHOLDER"
+      end
+
+      # Apply signature to PDF
+      # @param signature_or_callback [String, Proc] raw signature bytes or signing callback
+      # @param certificate_chain [Array<OpenSSL::X509::Certificate>] certificate chain
+      # @param timestamp_token [Timestamp::Response, Proc, nil] optional timestamp or lazy accessor
+      # @return [String] path to signed PDF
+      def apply_signature(signature_or_callback, certificate_chain, timestamp_token: nil)
+        prepare_for_signing if @prepared_data.nil?
+
+        signing_certificate = certificate_chain.first
+
+        # Create the signing handler with external signing support
+        signing_key = if signature_or_callback.respond_to?(:call)
+                        # Callback-based signing (for HSM)
+                        ExternalSigningCallback.new(signature_or_callback)
+                      else
+                        # Pre-computed signature
+                        ExternalSigningProxy.new(signature_or_callback, signing_certificate, certificate_chain)
+                      end
+
+        # Estimate signature size for placeholder
+        estimated_size = calculate_signature_size(certificate_chain, timestamp_token)
+
+        # Configure signature handler
+        handler = @document.signatures.handler_for_signing(
+          @signature_field,
+          certificate: signing_certificate,
+          key: signing_key,
+          certificate_chain: certificate_chain[1..] || [],
+          reason: @signature_config[:reason],
+          location: @signature_config[:location],
+          contact_info: @signature_config[:contact_info],
+          signature_size: estimated_size
+        )
+
+        # Build visible appearance if configured
+        if @signature_config[:visible]
+          build_visible_appearance(handler, signing_certificate)
+        end
+
+        # Write signed PDF
+        out_path = output_path
+        @document.signatures.sign(@signature_field, handler, write_options: { output: out_path })
+
+        out_path
+      end
+
+      # Extract existing signature from PDF
+      # @return [Hash, nil] signature data or nil if unsigned
+      def extract_signature
+        doc = HexaPDF::Document.open(file_path)
+
+        signatures = doc.signatures.each.to_a
+        return nil if signatures.empty?
+
+        # Return the last (most recent) signature
+        sig = signatures.last
+        sig_dict = sig[:V]
+
+        return nil unless sig_dict
+
+        {
+          contents: sig_dict[:Contents],
+          byte_range: sig_dict[:ByteRange]&.value,
+          sub_filter: sig_dict[:SubFilter]&.to_s,
+          reason: sig_dict[:Reason],
+          location: sig_dict[:Location],
+          contact_info: sig_dict[:ContactInfo],
+          signing_time: sig_dict[:M],
+          name: sig_dict[:Name]
+        }
+      rescue StandardError
+        nil
+      end
+
+      private
+
+      def validate_pdf!
+        ext = File.extname(file_path).downcase
+        unless SUPPORTED_EXTENSIONS.include?(ext)
+          raise InvalidPdfError, "File must be a PDF: #{file_path}"
+        end
+
+        # Verify PDF header
+        File.open(file_path, "rb") do |f|
+          header = f.read(8)
+          unless header&.start_with?("%PDF-")
+            raise InvalidPdfError, "Invalid PDF file (bad header): #{file_path}"
+          end
+        end
+      end
+
+      def build_signature_config(opts)
+        {
+          visible: opts.fetch(:visible_signature, false),
+          page: opts.fetch(:signature_page, 1),
+          position: opts.fetch(:signature_position, :bottom_right),
+          rect: opts[:signature_rect],
+          reason: opts[:signature_reason],
+          location: opts[:signature_location],
+          contact_info: opts[:signature_contact]
+        }
+      end
+
+      def create_signature_field
+        page_index = [@signature_config[:page] - 1, 0].max
+        page = @document.pages[page_index] || @document.pages.add
+
+        # Create signature form field
+        form = @document.acro_form(create: true)
+        sig_field = form.create_signature_field("Signature1")
+
+        # Add visible appearance if requested
+        if @signature_config[:visible]
+          sig_field.create_widget(page, Rect: calculate_signature_rect(page))
+          # Appearance will be built during signing
+        else
+          # Invisible signature
+          sig_field.create_widget(page, Rect: [0, 0, 0, 0])
+        end
+
+        sig_field
+      end
+
+      def calculate_signature_rect(page)
+        if @signature_config[:rect]
+          return @signature_config[:rect]
+        end
+
+        # Calculate position based on preset
+        box = page.box(:media)
+        width = 200
+        height = 50
+        margin = 36
+
+        case @signature_config[:position].to_sym
+        when :top_left
+          [margin, box.height - margin - height, margin + width, box.height - margin]
+        when :top_right
+          [box.width - margin - width, box.height - margin - height, box.width - margin, box.height - margin]
+        when :bottom_left
+          [margin, margin, margin + width, margin + height]
+        when :bottom_right
+          [box.width - margin - width, margin, box.width - margin, margin + height]
+        else
+          [box.width - margin - width, margin, box.width - margin, margin + height]
+        end
+      end
+
+      def calculate_signature_size(certificate_chain, timestamp_token)
+        # Estimate PKCS#7 signature size
+        # Base size + certificates + timestamp
+        base_size = 8192
+        cert_size = certificate_chain.sum { |c| c.to_der.bytesize }
+        timestamp_size = timestamp_token ? 4096 : 0
+
+        base_size + cert_size + timestamp_size
+      end
+
+      def build_visible_appearance(handler, certificate)
+        # Get the widget annotation for the signature field
+        widget = @signature_field.each_widget.first
+        return unless widget
+
+        rect = widget[:Rect].value
+        width = rect[2] - rect[0]
+        height = rect[3] - rect[1]
+
+        # Create appearance form XObject
+        form = @document.add({ Type: :XObject, Subtype: :Form, BBox: [0, 0, width, height] })
+        canvas = form.canvas
+
+        # Draw border
+        canvas.stroke_color(0, 0, 0)
+        canvas.line_width(0.5)
+        canvas.rectangle(0.5, 0.5, width - 1, height - 1)
+        canvas.stroke
+
+        # Draw signature text
+        canvas.font("Helvetica", size: 8)
+        canvas.fill_color(0, 0, 0)
+
+        y_pos = height - 12
+        x_pos = 5
+
+        # Signer name
+        signer_name = extract_cn_from_certificate(certificate)
+        canvas.text("Digitally signed by:", at: [x_pos, y_pos])
+        y_pos -= 10
+        canvas.text(signer_name, at: [x_pos, y_pos])
+        y_pos -= 12
+
+        # Reason
+        if @signature_config[:reason]
+          canvas.text("Reason: #{@signature_config[:reason]}", at: [x_pos, y_pos])
+          y_pos -= 10
+        end
+
+        # Location
+        if @signature_config[:location]
+          canvas.text("Location: #{@signature_config[:location]}", at: [x_pos, y_pos])
+          y_pos -= 10
+        end
+
+        # Date
+        canvas.text("Date: #{Time.now.strftime('%Y-%m-%d %H:%M')}", at: [x_pos, y_pos])
+
+        # Set the appearance
+        widget[:AP] = { N: form }
+      end
+
+      def extract_cn_from_certificate(certificate)
+        subject = certificate.subject.to_a
+        cn = subject.find { |name, _, _| name == "CN" }
+        cn ? cn[1] : certificate.subject.to_s
+      end
+    end
+
+    # Callback-based signing for HSM integration
+    # HexaPDF calls #sign with the actual data to sign (ByteRange content)
+    class ExternalSigningCallback
+      def initialize(signing_proc)
+        @signing_proc = signing_proc
+      end
+
+      # Called by HexaPDF during signing with the ByteRange content
+      def sign(data, _digest_algorithm)
+        @signing_proc.call(data)
+      end
+
+      def private?
+        true
+      end
+    end
+
+    # Proxy object that provides pre-computed signature to HexaPDF
+    # HexaPDF expects a key object that responds to #sign, but we've already
+    # signed with the HSM, so we return the pre-computed signature
+    class ExternalSigningProxy
+      attr_reader :certificate
+
+      def initialize(signature, certificate, certificate_chain)
+        @signature = signature
+        @certificate = certificate
+        @certificate_chain = certificate_chain
+      end
+
+      # Called by HexaPDF's DefaultHandler during signing
+      # Returns pre-computed signature from HSM
+      def sign(data, digest_algorithm)
+        @signature
+      end
+
+      # HexaPDF checks this for RSA keys
+      def private?
+        true
+      end
+    end
+  end
+end

--- a/lib/easy_code_sign/signable/pdf_file.rb
+++ b/lib/easy_code_sign/signable/pdf_file.rb
@@ -107,6 +107,118 @@ module EasyCodeSign
         out_path
       end
 
+      # Phase 1 of deferred signing: prepare PDF with placeholder signature,
+      # capture the digest that needs to be signed externally.
+      #
+      # HexaPDF builds the CMS signed attributes internally (since certificate IS set).
+      # The external_signing lambda receives (digest_algorithm, hash) where hash is the
+      # digest of the DER-encoded signed attributes — exactly what the external signer
+      # must sign. We capture it and return "" to leave the /Contents zero-filled.
+      #
+      # @param certificate [OpenSSL::X509::Certificate] signing certificate
+      # @param certificate_chain [Array<OpenSSL::X509::Certificate>] full chain
+      # @param digest_algorithm [String] "sha256", "sha384", or "sha512"
+      # @param timestamp_size [Integer] extra bytes to reserve for timestamp (0 if none)
+      # @return [DeferredSigningRequest]
+      def prepare_deferred(certificate, certificate_chain, digest_algorithm: "sha256", timestamp_size: 0)
+        captured_digest = nil
+        captured_algorithm = nil
+        signing_time = Time.now
+
+        external_signing = lambda do |algo, hash|
+          captured_algorithm = algo
+          captured_digest = hash
+          "" # Empty string signals async to HexaPDF
+        end
+
+        estimated_size = calculate_deferred_signature_size(certificate_chain, timestamp_size)
+
+        document = HexaPDF::Document.open(file_path)
+        handler = document.signatures.signing_handler(
+          certificate: certificate,
+          certificate_chain: certificate_chain[1..] || [],
+          external_signing: external_signing,
+          digest_algorithm: digest_algorithm,
+          signature_size: estimated_size,
+          signing_time: signing_time,
+          reason: @signature_config[:reason],
+          location: @signature_config[:location],
+          contact_info: @signature_config[:contact_info]
+        )
+
+        prepared_path = deferred_output_path
+        document.signatures.add(prepared_path, handler)
+
+        # Read back the ByteRange from the prepared PDF
+        byte_range = read_byte_range(prepared_path)
+
+        DeferredSigningRequest.new(
+          digest: captured_digest,
+          digest_algorithm: captured_algorithm,
+          prepared_pdf_path: prepared_path,
+          byte_range: byte_range,
+          certificate: certificate,
+          certificate_chain: certificate_chain,
+          estimated_size: estimated_size,
+          signing_time: signing_time
+        )
+      rescue HexaPDF::Error => e
+        raise DeferredSigningError, "Failed to prepare PDF for deferred signing: #{e.message}"
+      end
+
+      # Phase 2 of deferred signing: rebuild CMS with the real signature and embed it.
+      #
+      # Re-reads the ByteRange content from the prepared PDF, invokes SignedDataCreator
+      # with the same parameters as Phase 1 (including signing_time for determinism),
+      # and the block returns the actual raw signature. The resulting CMS DER is embedded
+      # into the prepared PDF via Signing.embed_signature.
+      #
+      # @param deferred_request [DeferredSigningRequest] from Phase 1
+      # @param raw_signature [String] raw signature bytes from external signer
+      # @return [String] path to the finalized signed PDF
+      def finalize_deferred(deferred_request, raw_signature)
+        prepared_path = deferred_request.prepared_pdf_path
+        unless File.exist?(prepared_path)
+          raise DeferredSigningError, "Prepared PDF not found: #{prepared_path}"
+        end
+
+        byte_range = deferred_request.byte_range
+
+        # Read ByteRange content from the prepared PDF
+        data = File.open(prepared_path, "rb") do |f|
+          f.pos = byte_range[0]
+          content = f.read(byte_range[1])
+          f.pos = byte_range[2]
+          content << f.read(byte_range[3])
+        end
+
+        # Rebuild the CMS structure with the actual signature
+        signing_block = lambda do |_digest_algorithm, _hash|
+          raw_signature
+        end
+
+        cms = HexaPDF::DigitalSignature::Signing::SignedDataCreator.create(
+          data,
+          type: :cms,
+          certificate: deferred_request.certificate,
+          digest_algorithm: deferred_request.digest_algorithm.to_s,
+          signing_time: deferred_request.signing_time,
+          certificates: deferred_request.certificate_chain[1..] || [],
+          &signing_block
+        )
+
+        cms_der = cms.to_der
+
+        # Embed the real signature into the prepared PDF
+        File.open(prepared_path, "rb+") do |io|
+          HexaPDF::DigitalSignature::Signing.embed_signature(io, cms_der)
+        end
+
+        prepared_path
+      rescue HexaPDF::Error => e
+        raise DeferredSigningError, "Failed to finalize deferred signature: #{e.message}"
+      end
+
       # Extract existing signature from PDF
       # @return [Hash, nil] signature data or nil if unsigned
       def extract_signature
@@ -115,9 +227,8 @@ module EasyCodeSign
         signatures = doc.signatures.each.to_a
         return nil if signatures.empty?
 
-        # Return the last (most recent) signature
-        sig = signatures.last
-        sig_dict = sig[:V]
+        # HexaPDF's signatures.each yields the Sig dictionary directly
+        sig_dict = signatures.last
 
         return nil unless sig_dict
 
@@ -207,6 +318,25 @@ module EasyCodeSign
         else
           [box.width - margin - width, margin, box.width - margin, margin + height]
         end
+      end
+
+      def calculate_deferred_signature_size(certificate_chain, timestamp_size)
+        base_size = 8192
+        cert_size = certificate_chain.sum { |c| c.to_der.bytesize }
+        base_size + cert_size + timestamp_size
+      end
+
+      def deferred_output_path
+        dir = File.dirname(file_path)
+        base = File.basename(file_path, File.extname(file_path))
+        File.join(dir, "#{base}_prepared.pdf")
+      end
+
+      def read_byte_range(pdf_path)
+        doc = HexaPDF::Document.open(pdf_path)
+        sig = doc.signatures.each.to_a.last
+        sig_dict = sig.is_a?(Hash) ? sig : sig
+        sig_dict[:ByteRange]&.value
       end
 
       def calculate_signature_size(certificate_chain, timestamp_token)

--- a/lib/easy_code_sign/signable/pdf_file.rb
+++ b/lib/easy_code_sign/signable/pdf_file.rb
@@ -92,7 +92,8 @@ module EasyCodeSign
           reason: @signature_config[:reason],
           location: @signature_config[:location],
           contact_info: @signature_config[:contact_info],
-          signature_size: estimated_size
+          signature_size: estimated_size,
+          timestamp_handler: timestamp_token ? Pdf::TimestampHandler.new(timestamp_token) : nil
         )
 
         # Build visible appearance if configured
@@ -183,7 +184,7 @@ module EasyCodeSign
       # @param deferred_request [DeferredSigningRequest] from Phase 1
       # @param raw_signature [String] raw signature bytes from external signer
       # @return [String] path to the finalized signed PDF
-      def finalize_deferred(deferred_request, raw_signature)
+      def finalize_deferred(deferred_request, raw_signature, timestamp_token: nil)
         prepared_path = deferred_request.prepared_pdf_path
         unless File.exist?(prepared_path)
           raise DeferredSigningError, "Prepared PDF not found: #{prepared_path}"
@@ -204,15 +205,14 @@ module EasyCodeSign
           raw_signature
         end
 
-        cms = HexaPDF::DigitalSignature::Signing::SignedDataCreator.create(
-          data,
-          type: :cms,
-          certificate: deferred_request.certificate,
-          digest_algorithm: deferred_request.digest_algorithm.to_s,
-          signing_time: deferred_request.signing_time,
-          certificates: deferred_request.certificate_chain[1..] || [],
-          &signing_block
-        )
+        creator = HexaPDF::DigitalSignature::Signing::SignedDataCreator.new
+        creator.certificate = deferred_request.certificate
+        creator.digest_algorithm = deferred_request.digest_algorithm.to_s
+        creator.signing_time = deferred_request.signing_time
+        creator.certificates = deferred_request.certificate_chain[1..] || []
+        creator.timestamp_handler = Pdf::TimestampHandler.new(timestamp_token) if timestamp_token
+
+        cms = creator.create(data, type: :cms, &signing_block)
 
         cms_der = cms.to_der
 

--- a/lib/easy_code_sign/signable/pdf_file.rb
+++ b/lib/easy_code_sign/signable/pdf_file.rb
@@ -152,6 +152,12 @@ module EasyCodeSign
         # Read back the ByteRange from the prepared PDF
         byte_range = read_byte_range(prepared_path)
 
+        # Compute pre-hash signed attributes DER for WebCrypto compatibility
+        signed_attrs_der = compute_signed_attributes_data(
+          prepared_path, byte_range, certificate, certificate_chain,
+          digest_algorithm, signing_time
+        )
+
         DeferredSigningRequest.new(
           digest: captured_digest,
           digest_algorithm: captured_algorithm,
@@ -160,7 +166,8 @@ module EasyCodeSign
           certificate: certificate,
           certificate_chain: certificate_chain,
           estimated_size: estimated_size,
-          signing_time: signing_time
+          signing_time: signing_time,
+          signed_attributes_data: signed_attrs_der
         )
       rescue HexaPDF::Error => e
         raise DeferredSigningError, "Failed to prepare PDF for deferred signing: #{e.message}"
@@ -337,6 +344,33 @@ module EasyCodeSign
         sig = doc.signatures.each.to_a.last
         sig_dict = sig.is_a?(Hash) ? sig : sig
         sig_dict[:ByteRange]&.value
+      end
+
+      # Reconstruct the DER-encoded signed attributes from the prepared PDF.
+      # This is the pre-hash data that WebCrypto can hash-and-sign in one step.
+      # Invariant: SHA256(result) == captured_digest
+      def compute_signed_attributes_data(prepared_path, byte_range, certificate, certificate_chain,
+                                         digest_algorithm, signing_time)
+        # Read ByteRange content (same as finalize_deferred does)
+        data = File.open(prepared_path, "rb") do |f|
+          f.pos = byte_range[0]
+          content = f.read(byte_range[1])
+          f.pos = byte_range[2]
+          content << f.read(byte_range[3])
+        end
+
+        # Build a SignedDataCreator with the same params used in Phase 1
+        creator = HexaPDF::DigitalSignature::Signing::SignedDataCreator.new
+        creator.certificate = certificate
+        creator.digest_algorithm = digest_algorithm.to_s
+        creator.signing_time = signing_time
+        creator.certificates = certificate_chain[1..] || []
+
+        # Access the private method to get the ASN.1 signed attributes SET
+        signed_attrs = creator.send(:create_signed_attrs, data, signing_time: true)
+
+        # DER-encode the SET (mirrors line 113 of signed_data_creator.rb)
+        OpenSSL::ASN1::Set.new(signed_attrs.value).to_der
       end
 
       def calculate_signature_size(certificate_chain, timestamp_token)

--- a/lib/easy_code_sign/signer.rb
+++ b/lib/easy_code_sign/signer.rb
@@ -109,16 +109,22 @@ module EasyCodeSign
     # @param deferred_request [DeferredSigningRequest] from Phase 1
     # @param raw_signature [String] raw signature bytes from the external signer
     # @return [SigningResult]
-    def finalize_pdf(deferred_request, raw_signature)
+    def finalize_pdf(deferred_request, raw_signature, timestamp: nil, timestamp_token: nil)
+      timestamp = configuration.require_timestamp if timestamp.nil?
+
+      if timestamp && timestamp_token.nil?
+        timestamp_token = request_timestamp(raw_signature)
+      end
+
       signable = Signable::PdfFile.new(deferred_request.prepared_pdf_path)
 
-      signed_path = signable.finalize_deferred(deferred_request, raw_signature)
+      signed_path = signable.finalize_deferred(deferred_request, raw_signature, timestamp_token: timestamp_token)
 
       SigningResult.new(
         file_path: signed_path,
         certificate: deferred_request.certificate,
         algorithm: :"#{deferred_request.digest_algorithm}_rsa",
-        timestamp_token: nil,
+        timestamp_token: timestamp_token,
         signed_at: deferred_request.signing_time
       )
     end

--- a/lib/easy_code_sign/signer.rb
+++ b/lib/easy_code_sign/signer.rb
@@ -28,30 +28,44 @@ module EasyCodeSign
     # @param algorithm [Symbol] signature algorithm (:sha256_rsa, etc.)
     # @return [SigningResult] result containing signed file path and metadata
     #
-    def sign(file_path, pin: nil, output_path: nil, timestamp: nil, algorithm: :sha256_rsa)
+    def sign(file_path, pin: nil, output_path: nil, timestamp: nil, algorithm: :sha256_rsa, **extra_options)
       timestamp = configuration.require_timestamp if timestamp.nil?
 
-      signable = create_signable(file_path, output_path: output_path, algorithm: algorithm)
+      signable = create_signable(file_path, output_path: output_path, algorithm: algorithm, **extra_options)
       signable.prepare_for_signing
 
       provider.with_session(pin: pin) do |session|
-        # Get content to sign
-        content = signable.content_to_sign
-
-        # Sign with hardware token
-        signature = session.sign(content, algorithm: algorithm)
-
-        # Get certificate chain
         certificate_chain = session.certificate_chain
-
-        # Get timestamp if requested
         timestamp_token = nil
-        if timestamp
-          timestamp_token = request_timestamp(signature)
-        end
 
-        # Apply signature to file
-        signed_path = signable.apply_signature(signature, certificate_chain, timestamp_token: timestamp_token)
+        # PDF files use deferred signing (callback-based)
+        if signable.is_a?(Signable::PdfFile)
+          # Create signing callback for PDF
+          signing_callback = lambda do |data_to_sign|
+            sig = session.sign(data_to_sign, algorithm: algorithm)
+            # Request timestamp on the signature if needed
+            if timestamp
+              timestamp_token = request_timestamp(sig)
+            end
+            sig
+          end
+
+          signed_path = signable.apply_signature(
+            signing_callback,
+            certificate_chain,
+            timestamp_token: -> { timestamp_token }  # Lazy accessor since it's set in callback
+          )
+        else
+          # Standard flow for gem/zip files
+          content = signable.content_to_sign
+          signature = session.sign(content, algorithm: algorithm)
+
+          if timestamp
+            timestamp_token = request_timestamp(signature)
+          end
+
+          signed_path = signable.apply_signature(signature, certificate_chain, timestamp_token: timestamp_token)
+        end
 
         SigningResult.new(
           file_path: signed_path,
@@ -94,9 +108,11 @@ module EasyCodeSign
         Signable::GemFile.new(file_path, **options)
       when ".zip", ".jar", ".apk", ".war", ".ear"
         Signable::ZipFile.new(file_path, **options)
+      when ".pdf"
+        Signable::PdfFile.new(file_path, **options)
       else
         raise InvalidFileError, "Unsupported file type: #{extension}. " \
-                                "Supported: .gem, .zip, .jar, .apk, .war, .ear"
+                                "Supported: .gem, .zip, .jar, .apk, .war, .ear, .pdf"
       end
     end
 

--- a/lib/easy_code_sign/signer.rb
+++ b/lib/easy_code_sign/signer.rb
@@ -77,6 +77,52 @@ module EasyCodeSign
       end
     end
 
+    # Phase 1 of deferred PDF signing: prepare a PDF with a placeholder signature
+    # and return a DeferredSigningRequest containing the digest to be signed externally.
+    #
+    # Requires a hardware token session (PIN) to retrieve the signing certificate.
+    #
+    # @param file_path [String] path to the PDF
+    # @param pin [String, nil] PIN for hardware token
+    # @param digest_algorithm [String] hash algorithm ("sha256", "sha384", "sha512")
+    # @param timestamp [Boolean] whether to reserve space for a timestamp
+    # @return [DeferredSigningRequest]
+    def prepare_pdf(file_path, pin: nil, digest_algorithm: "sha256", timestamp: false, **extra_options)
+      signable = Signable::PdfFile.new(file_path, **extra_options)
+      timestamp_size = timestamp ? 4096 : 0
+
+      provider.with_session(pin: pin) do |session|
+        certificate_chain = session.certificate_chain
+
+        signable.prepare_deferred(
+          certificate_chain.first,
+          certificate_chain,
+          digest_algorithm: digest_algorithm,
+          timestamp_size: timestamp_size
+        )
+      end
+    end
+
+    # Phase 2 of deferred PDF signing: embed an externally-produced signature
+    # into the prepared PDF. No hardware token needed.
+    #
+    # @param deferred_request [DeferredSigningRequest] from Phase 1
+    # @param raw_signature [String] raw signature bytes from the external signer
+    # @return [SigningResult]
+    def finalize_pdf(deferred_request, raw_signature)
+      signable = Signable::PdfFile.new(deferred_request.prepared_pdf_path)
+
+      signed_path = signable.finalize_deferred(deferred_request, raw_signature)
+
+      SigningResult.new(
+        file_path: signed_path,
+        certificate: deferred_request.certificate,
+        algorithm: :"#{deferred_request.digest_algorithm}_rsa",
+        timestamp_token: nil,
+        signed_at: deferred_request.signing_time
+      )
+    end
+
     # Sign multiple files
     #
     # @param file_paths [Array<String>] paths to files to sign

--- a/lib/easy_code_sign/verifier.rb
+++ b/lib/easy_code_sign/verifier.rb
@@ -57,6 +57,8 @@ module EasyCodeSign
           verify_gem(signable, signature_data, result)
         when :zipfile
           verify_zip(signable, signature_data, result)
+        when :pdffile
+          verify_pdf(signable, signature_data, result)
         else
           result.add_error("Unsupported file type for verification")
           return result
@@ -117,6 +119,8 @@ module EasyCodeSign
         Signable::GemFile.new(file_path)
       when ".zip", ".jar", ".apk", ".war", ".ear"
         Signable::ZipFile.new(file_path)
+      when ".pdf"
+        Signable::PdfFile.new(file_path)
       else
         raise InvalidFileError, "Unsupported file type: #{extension}"
       end
@@ -187,6 +191,93 @@ module EasyCodeSign
 
       # Verify manifest integrity
       verify_zip_manifest(signable, manifest, signature_file, result)
+    end
+
+    def verify_pdf(signable, signature_data, result)
+      signature_checker = Verification::SignatureChecker.new
+
+      # PDF signatures store PKCS#7 in /Contents and signed data via ByteRange
+      contents = signature_data[:contents]
+      byte_range = signature_data[:byte_range]
+
+      unless contents && byte_range
+        result.add_error("Invalid PDF signature (missing Contents or ByteRange)")
+        return
+      end
+
+      # Read the ByteRange content from the file
+      signed_content = read_byte_range_content(signable.file_path, byte_range)
+
+      # Verify PKCS#7 signature
+      sig_result = signature_checker.verify_pkcs7(contents, signed_content, trust_store)
+
+      result.signature_valid = sig_result.signature_valid
+      result.signer_certificate = sig_result.signer_certificate
+      result.certificate_chain = sig_result.certificates
+      result.signature_algorithm = sig_result.signature_algorithm
+
+      sig_result.errors.each { |e| result.add_error(e) }
+
+      if result.signer_certificate
+        extract_signer_info(result)
+        verify_certificate_chain(result)
+      end
+
+      # Verify PDF integrity (ByteRange covers the document properly)
+      verify_pdf_integrity(signable, signature_data, result)
+
+      # Extract signer info from PDF signature dict
+      extract_pdf_signature_info(signature_data, result)
+    end
+
+    def read_byte_range_content(file_path, byte_range)
+      # ByteRange = [offset1, length1, offset2, length2]
+      # The signed content is: bytes[offset1..offset1+length1] + bytes[offset2..offset2+length2]
+      File.open(file_path, "rb") do |f|
+        f.seek(byte_range[0])
+        part1 = f.read(byte_range[1])
+        f.seek(byte_range[2])
+        part2 = f.read(byte_range[3])
+        part1 + part2
+      end
+    end
+
+    def verify_pdf_integrity(signable, signature_data, result)
+      result.integrity_valid = true
+
+      byte_range = signature_data[:byte_range]
+      return unless byte_range
+
+      file_size = File.size(signable.file_path)
+
+      # Verify ByteRange makes sense:
+      # [0, before_sig_offset, after_sig_offset, rest_of_file]
+      # The end should match file size
+      expected_end = byte_range[2] + byte_range[3]
+
+      unless expected_end == file_size
+        result.integrity_valid = false
+        result.add_error("PDF ByteRange does not cover entire document (expected #{file_size}, got #{expected_end})")
+      end
+
+      # Verify no gap exists (signature placeholder should be between the two ranges)
+      signature_start = byte_range[0] + byte_range[1]
+      signature_end = byte_range[2]
+
+      if signature_start > signature_end
+        result.integrity_valid = false
+        result.add_error("Invalid PDF ByteRange (overlapping ranges)")
+      end
+    end
+
+    def extract_pdf_signature_info(signature_data, result)
+      # Extract additional info from PDF signature dictionary
+      result.signature_reason = signature_data[:reason] if signature_data[:reason]
+      result.signature_location = signature_data[:location] if signature_data[:location]
+
+      # Check for timestamp
+      # This would require parsing the unsigned attributes of the PKCS#7
+      # For now, we don't extract embedded timestamps from PDF
     end
 
     def verify_certificate_chain(result)

--- a/plugin/.gitignore
+++ b/plugin/.gitignore
@@ -1,0 +1,21 @@
+# Built extension output
+dist/
+
+# Ruby dependencies
+.bundle/
+vendor/bundle/
+
+# Logs
+*.log
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor files
+*.swp
+*.swo
+*~
+
+# Native host packaged binaries
+native_host/dist/

--- a/plugin/Gemfile
+++ b/plugin/Gemfile
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Opal - Ruby to JavaScript compiler
+gem "opal", "~> 1.8"
+gem "opal-sprockets", "~> 1.0"
+
+# Required for Ruby 3.4+
+gem "base64"
+
+# Build tooling
+gem "rake", "~> 13.0"
+
+# For watching file changes during development
+gem "listen", "~> 3.8"
+
+# Testing - use minitest (native host tests are plain Ruby)
+gem "minitest", "~> 5.0"
+
+group :development do
+  # Code quality
+  gem "rubocop", require: false
+end

--- a/plugin/Gemfile.lock
+++ b/plugin/Gemfile.lock
@@ -1,0 +1,134 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.3)
+    base64 (0.3.0)
+    concurrent-ruby (1.3.6)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-aarch64-linux-musl)
+    ffi (1.17.3-arm-linux-gnu)
+    ffi (1.17.3-arm-linux-musl)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86-linux-gnu)
+    ffi (1.17.3-x86-linux-musl)
+    ffi (1.17.3-x86_64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-musl)
+    json (2.18.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    minitest (5.27.0)
+    opal (1.8.2)
+      ast (>= 2.3.0)
+      parser (~> 3.0, >= 3.0.3.2)
+    opal-sprockets (1.0.4)
+      opal (>= 1.0, < 2.0)
+      sprockets (~> 4.0)
+      tilt (>= 1.4)
+    parallel (1.27.0)
+    parser (3.3.10.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.7.0)
+    racc (1.8.1)
+    rack (3.2.4)
+    rainbow (3.1.1)
+    rake (13.3.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    regexp_parser (2.11.3)
+    rubocop (1.82.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.48.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
+    sprockets (4.2.2)
+      concurrent-ruby (~> 1.0)
+      logger
+      rack (>= 2.2.4, < 4)
+    tilt (2.6.1)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  base64
+  listen (~> 3.8)
+  minitest (~> 5.0)
+  opal (~> 1.8)
+  opal-sprockets (~> 1.0)
+  rake (~> 13.0)
+  rubocop
+
+CHECKSUMS
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  ffi (1.17.3) sha256=0e9f39f7bb3934f77ad6feab49662be77e87eedcdeb2a3f5c0234c2938563d4c
+  ffi (1.17.3-aarch64-linux-gnu) sha256=28ad573df26560f0aedd8a90c3371279a0b2bd0b4e834b16a2baa10bd7a97068
+  ffi (1.17.3-aarch64-linux-musl) sha256=020b33b76775b1abacc3b7d86b287cef3251f66d747092deec592c7f5df764b2
+  ffi (1.17.3-arm-linux-gnu) sha256=5bd4cea83b68b5ec0037f99c57d5ce2dd5aa438f35decc5ef68a7d085c785668
+  ffi (1.17.3-arm-linux-musl) sha256=0d7626bb96265f9af78afa33e267d71cfef9d9a8eb8f5525344f8da6c7d76053
+  ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
+  ffi (1.17.3-x86-linux-gnu) sha256=868a88fcaf5186c3a46b7c7c2b2c34550e1e61a405670ab23f5b6c9971529089
+  ffi (1.17.3-x86-linux-musl) sha256=f0286aa6ef40605cf586e61406c446de34397b85dbb08cc99fdaddaef8343945
+  ffi (1.17.3-x86_64-darwin) sha256=1f211811eb5cfaa25998322cdd92ab104bfbd26d1c4c08471599c511f2c00bb5
+  ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
+  ffi (1.17.3-x86_64-linux-musl) sha256=086b221c3a68320b7564066f46fed23449a44f7a1935f1fe5a245bd89d9aea56
+  json (2.18.0) sha256=b10506aee4183f5cf49e0efc48073d7b75843ce3782c68dbeb763351c08fd505
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  listen (3.9.0) sha256=db9e4424e0e5834480385197c139cb6b0ae0ef28cc13310cfd1ca78377d59c67
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
+  opal (1.8.2) sha256=cedde4e1691d7cdaaf0aadac99fbf1fdb5bb90fe2dcc60e968f984601bd5d4e3
+  opal-sprockets (1.0.4) sha256=ba247b54c1cea23a4858f70a8851322c170436ed904b2c9c9d76d0b07e25ccfc
+  parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
+  parser (3.3.10.0) sha256=ce3587fa5cc55a88c4ba5b2b37621b3329aadf5728f9eafa36bbd121462aabd6
+  prism (1.7.0) sha256=10062f734bf7985c8424c44fac382ac04a58124ea3d220ec3ba9fe4f2da65103
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (3.2.4) sha256=5d74b6f75082a643f43c1e76b419c40f0e5527fcfee1e669ac1e6b73c0ccb6f6
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
+  rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
+  regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
+  rubocop (1.82.1) sha256=09f1a6a654a960eda767aebea33e47603080f8e9c9a3f019bf9b94c9cab5e273
+  rubocop-ast (1.49.0) sha256=49c3676d3123a0923d333e20c6c2dbaaae2d2287b475273fddee0c61da9f71fd
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1
+  tilt (2.6.1) sha256=35a99bba2adf7c1e362f5b48f9b581cce4edfba98117e34696dde6d308d84770
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+
+BUNDLED WITH
+  4.0.3

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,248 @@
+# EasySign Browser Plugin
+
+Browser extension for signing PDF documents using hardware security tokens (HSM/smart cards).
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Web App (Rails, etc.)                              │
+│  window.EasySign.sign(pdfBlob, options)            │
+└─────────────────┬───────────────────────────────────┘
+                  │ postMessage
+┌─────────────────▼───────────────────────────────────┐
+│  Content Script (Opal.rb → JS)                      │
+│  Bridges page ↔ extension, validates origins        │
+└─────────────────┬───────────────────────────────────┘
+                  │ chrome.runtime.sendMessage
+┌─────────────────▼───────────────────────────────────┐
+│  Background Service Worker (Opal.rb → JS)           │
+│  Opens PIN popup, manages native connection         │
+└─────────────────┬───────────────────────────────────┘
+                  │ Native Messaging (JSON over stdio)
+┌─────────────────▼───────────────────────────────────┐
+│  Native Host (Ruby → Packaged Binary)               │
+│  Uses EasyCodeSign gem for actual signing           │
+│  Accesses PKCS#11 hardware token                    │
+└─────────────────────────────────────────────────────┘
+```
+
+## Development Setup
+
+### Prerequisites
+
+- Ruby 3.2+
+- Node.js (optional, for alternative build tools)
+- Chrome or Firefox browser
+
+### Install Dependencies
+
+```bash
+cd plugin
+bundle install
+```
+
+### Build Extension
+
+```bash
+# Build all components
+bundle exec rake build
+
+# Watch for changes during development
+bundle exec rake watch
+
+# Clean build artifacts
+bundle exec rake clean
+```
+
+### Load Extension in Browser
+
+**Chrome:**
+1. Open `chrome://extensions`
+2. Enable "Developer mode"
+3. Click "Load unpacked"
+4. Select the `plugin/dist` directory
+
+**Firefox:**
+1. Open `about:debugging`
+2. Click "This Firefox"
+3. Click "Load Temporary Add-on"
+4. Select `plugin/dist/manifest.json`
+
+### Install Native Host (Development)
+
+```bash
+# For Chrome
+./native_host/install/install_chrome.sh
+
+# For Firefox
+./native_host/install/install_firefox.sh
+```
+
+## Web App Integration
+
+### Check Availability
+
+```javascript
+window.EasySign.isAvailable()
+  .then(result => {
+    console.log('Extension installed:', result.available);
+    console.log('Token connected:', result.tokenPresent);
+    console.log('Available slots:', result.slots);
+  })
+  .catch(err => {
+    console.error('EasySign not available:', err);
+  });
+```
+
+### Sign a PDF
+
+```javascript
+// Get PDF as Blob (from file input, fetch, etc.)
+const pdfBlob = await fetch('/document.pdf').then(r => r.blob());
+
+// Sign the PDF
+window.EasySign.sign(pdfBlob, {
+  reason: 'Approved',
+  location: 'New York',
+  visibleSignature: true,
+  signaturePosition: 'bottom_right',
+  timestamp: true
+})
+.then(result => {
+  console.log('Signed by:', result.signer_name);
+  console.log('Signed at:', result.signed_at);
+
+  // Download signed PDF
+  const url = URL.createObjectURL(result.blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'signed_document.pdf';
+  a.click();
+
+  // Or upload to server
+  const formData = new FormData();
+  formData.append('signed_pdf', result.blob, 'signed.pdf');
+  fetch('/upload', { method: 'POST', body: formData });
+})
+.catch(err => {
+  console.error('Signing failed:', err.message, err.code);
+});
+```
+
+### Verify a Signed PDF
+
+```javascript
+window.EasySign.verify(signedPdfBlob)
+  .then(result => {
+    if (result.payload.valid) {
+      console.log('Signature is valid!');
+      console.log('Signer:', result.payload.signerName);
+    } else {
+      console.log('Signature invalid:', result.payload.errors);
+    }
+  });
+```
+
+## API Reference
+
+### `window.EasySign.isAvailable()`
+
+Check if extension is installed and token is connected.
+
+**Returns:** `Promise<Object>`
+- `available` (boolean): Extension is installed and native host is connected
+- `tokenPresent` (boolean): Hardware token is connected
+- `slots` (Array): List of available token slots
+
+### `window.EasySign.sign(pdfBlob, options)`
+
+Sign a PDF document. Opens PIN entry popup.
+
+**Parameters:**
+- `pdfBlob` (Blob): The PDF file to sign
+- `options` (Object):
+  - `reason` (string): Reason for signing
+  - `location` (string): Location of signing
+  - `visibleSignature` (boolean): Add visible signature annotation
+  - `signaturePosition` (string): Position (`top_left`, `top_right`, `bottom_left`, `bottom_right`)
+  - `signaturePage` (number): Page number for signature (default: 1)
+  - `timestamp` (boolean): Add RFC 3161 timestamp
+
+**Returns:** `Promise<Object>`
+- `blob` (Blob): Signed PDF file
+- `signer_name` (string): Name from signing certificate
+- `signed_at` (string): ISO 8601 timestamp
+- `timestamped` (boolean): Whether timestamp was added
+
+### `window.EasySign.verify(pdfBlob, options)`
+
+Verify a signed PDF document.
+
+**Parameters:**
+- `pdfBlob` (Blob): The signed PDF file
+- `options` (Object):
+  - `checkTimestamp` (boolean): Verify timestamp (default: true)
+
+**Returns:** `Promise<Object>` with verification details
+
+## Error Handling
+
+```javascript
+window.EasySign.sign(pdfBlob, options)
+  .catch(err => {
+    switch (err.code) {
+      case 'TOKEN_NOT_FOUND':
+        alert('Please connect your hardware token');
+        break;
+      case 'PIN_INCORRECT':
+        alert('Incorrect PIN');
+        break;
+      case 'TOKEN_LOCKED':
+        alert('Token is locked. Contact administrator.');
+        break;
+      case 'CANCELLED':
+        // User cancelled - no action needed
+        break;
+      default:
+        alert('Signing failed: ' + err.message);
+    }
+  });
+```
+
+## Building for Production
+
+### Package Native Host
+
+The native host can be packaged as a self-contained executable:
+
+```bash
+cd native_host
+bundle exec rake build:package
+```
+
+This creates platform-specific binaries in `native_host/dist/`.
+
+### Create Installer
+
+```bash
+# macOS
+./create_installer_macos.sh
+
+# Windows
+./create_installer_windows.bat
+
+# Linux
+./create_installer_linux.sh
+```
+
+## Security
+
+- PIN is entered only in browser popup, never on web pages
+- PIN is passed directly to native host, never stored
+- Origin validation restricts which websites can use the API
+- All signing happens in the native host, private keys never leave the token
+
+## License
+
+MIT License - See LICENSE file

--- a/plugin/Rakefile
+++ b/plugin/Rakefile
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "opal"
+require "fileutils"
+
+DIST_DIR = File.expand_path("dist", __dir__)
+SRC_DIR = File.expand_path("src", __dir__)
+
+desc "Build all extension components"
+task build: ["build:background", "build:content", "build:inject", "build:popup", "build:manifest", "build:assets"]
+
+namespace :build do
+  desc "Build background service worker"
+  task :background do
+    puts "Building background.js..."
+    compile_opal("easy_sign/background", "background.js")
+  end
+
+  desc "Build content script"
+  task :content do
+    puts "Building content.js..."
+    compile_opal("easy_sign/content", "content.js")
+  end
+
+  desc "Build injected page script"
+  task :inject do
+    puts "Building inject.js..."
+    compile_opal("easy_sign/inject", "inject.js")
+  end
+
+  desc "Build popup script"
+  task :popup do
+    puts "Building popup.js..."
+    compile_opal("easy_sign/popup", "popup/popup.js")
+
+    # Copy popup HTML and CSS
+    FileUtils.mkdir_p("#{DIST_DIR}/popup")
+    FileUtils.cp("templates/popup.html", "#{DIST_DIR}/popup/popup.html")
+    FileUtils.cp("templates/popup.css", "#{DIST_DIR}/popup/popup.css")
+  end
+
+  desc "Copy manifest.json"
+  task :manifest do
+    puts "Copying manifest.json..."
+    FileUtils.mkdir_p(DIST_DIR)
+    FileUtils.cp("templates/manifest.json", "#{DIST_DIR}/manifest.json")
+  end
+
+  desc "Copy static assets (icons, etc)"
+  task :assets do
+    puts "Copying assets..."
+    FileUtils.mkdir_p("#{DIST_DIR}/icons")
+    if Dir.exist?("assets/icons")
+      FileUtils.cp_r("assets/icons/.", "#{DIST_DIR}/icons/")
+    end
+  end
+end
+
+desc "Watch for changes and rebuild"
+task :watch do
+  require "listen"
+
+  puts "Watching for changes in src/ and templates/..."
+
+  listener = Listen.to(SRC_DIR, "templates") do |modified, added, removed|
+    puts "\nChanges detected: #{(modified + added + removed).join(', ')}"
+    Rake::Task["build"].reenable
+    Rake::Task["build"].invoke
+    puts "Rebuild complete."
+  end
+
+  listener.start
+  puts "Press Ctrl+C to stop."
+  sleep
+end
+
+desc "Clean dist directory"
+task :clean do
+  puts "Cleaning dist/..."
+  FileUtils.rm_rf(Dir.glob("#{DIST_DIR}/*"))
+  puts "Clean complete."
+end
+
+desc "Run tests"
+task :test do
+  require "minitest/autorun"
+  Dir.glob("test/**/*_test.rb").each { |f| require_relative f }
+end
+
+# Development server for testing
+desc "Start a simple HTTP server for testing"
+task :server do
+  require "webrick"
+  server = WEBrick::HTTPServer.new(Port: 8080, DocumentRoot: DIST_DIR)
+  trap("INT") { server.shutdown }
+  puts "Serving dist/ at http://localhost:8080"
+  server.start
+end
+
+def compile_opal(entry_point, output_file)
+  # Create a fresh builder with custom paths
+  builder = Opal::Builder.new(
+    stubs: [],
+    compiler_options: {
+      dynamic_require_severity: :ignore
+    }
+  )
+
+  # Add source directory to builder's path
+  builder.append_paths(SRC_DIR)
+
+  # Build the entry point
+  builder.build(entry_point)
+
+  output_path = File.join(DIST_DIR, output_file)
+  FileUtils.mkdir_p(File.dirname(output_path))
+
+  File.write(output_path, builder.to_s)
+  puts "  -> #{output_path} (#{File.size(output_path)} bytes)"
+end

--- a/plugin/docs/API_REFERENCE.md
+++ b/plugin/docs/API_REFERENCE.md
@@ -1,0 +1,366 @@
+# EasySign API Reference
+
+The EasySign browser extension exposes a `window.EasySign` object that web applications can use to sign and verify PDF documents using hardware security tokens.
+
+## Overview
+
+```javascript
+// Check if EasySign is available
+const status = await window.EasySign.isAvailable();
+
+// Sign a PDF
+const result = await window.EasySign.sign(pdfBlob, options);
+
+// Verify a signed PDF
+const verification = await window.EasySign.verify(pdfBlob);
+```
+
+## Methods
+
+### `window.EasySign.isAvailable()`
+
+Check if the EasySign extension is installed and the hardware token is connected.
+
+**Parameters:** None
+
+**Returns:** `Promise<AvailabilityResult>`
+
+```typescript
+interface AvailabilityResult {
+  available: boolean;      // Extension and native host are working
+  tokenPresent: boolean;   // Hardware token is connected
+  slots: TokenSlot[];      // List of available token slots
+}
+
+interface TokenSlot {
+  index: number;           // Slot index
+  tokenLabel: string;      // Token display name
+  manufacturer: string;    // Token manufacturer
+  serial: string;          // Token serial number
+}
+```
+
+**Example:**
+```javascript
+window.EasySign.isAvailable()
+  .then(result => {
+    if (!result.available) {
+      alert('Please install the EasySign extension');
+      return;
+    }
+    if (!result.tokenPresent) {
+      alert('Please connect your hardware token');
+      return;
+    }
+    console.log('Ready to sign!', result.slots);
+  })
+  .catch(err => {
+    console.error('EasySign error:', err);
+  });
+```
+
+---
+
+### `window.EasySign.sign(pdfBlob, options)`
+
+Sign a PDF document. Opens a popup for secure PIN entry.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `pdfBlob` | `Blob` | Yes | The PDF file to sign |
+| `options` | `SignOptions` | No | Signing options |
+
+```typescript
+interface SignOptions {
+  // Signature metadata
+  reason?: string;              // Reason for signing (e.g., "Approved")
+  location?: string;            // Location of signing (e.g., "New York")
+
+  // Visible signature
+  visibleSignature?: boolean;   // Add visible signature annotation (default: false)
+  signaturePosition?: string;   // Position: "top_left", "top_right", "bottom_left", "bottom_right"
+  signaturePage?: number;       // Page number for signature (default: 1)
+
+  // Timestamp
+  timestamp?: boolean;          // Add RFC 3161 timestamp (default: false)
+  timestampAuthority?: string;  // TSA URL (default: http://timestamp.digicert.com)
+}
+```
+
+**Returns:** `Promise<SignResult>`
+
+```typescript
+interface SignResult {
+  blob: Blob;              // The signed PDF file
+  signer_name: string;     // Certificate common name
+  signed_at: string;       // ISO 8601 timestamp
+  timestamped: boolean;    // Whether timestamp was added
+}
+```
+
+**Example:**
+```javascript
+// Get PDF from file input
+const fileInput = document.getElementById('pdf-file');
+const pdfBlob = fileInput.files[0];
+
+// Sign with options
+window.EasySign.sign(pdfBlob, {
+  reason: 'Document approved',
+  location: 'New York, NY',
+  visibleSignature: true,
+  signaturePosition: 'bottom_right',
+  timestamp: true
+})
+.then(result => {
+  console.log('Signed by:', result.signer_name);
+  console.log('Signed at:', result.signed_at);
+
+  // Download the signed PDF
+  const url = URL.createObjectURL(result.blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'signed_document.pdf';
+  link.click();
+  URL.revokeObjectURL(url);
+})
+.catch(err => {
+  if (err.code === 'CANCELLED') {
+    console.log('User cancelled signing');
+  } else {
+    console.error('Signing failed:', err.message);
+  }
+});
+```
+
+---
+
+### `window.EasySign.verify(pdfBlob, options)`
+
+Verify a signed PDF document.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `pdfBlob` | `Blob` | Yes | The signed PDF file to verify |
+| `options` | `VerifyOptions` | No | Verification options |
+
+```typescript
+interface VerifyOptions {
+  checkTimestamp?: boolean;  // Verify timestamp (default: true)
+}
+```
+
+**Returns:** `Promise<VerifyResult>`
+
+```typescript
+interface VerifyResult {
+  payload: {
+    valid: boolean;              // Overall signature validity
+    signerName: string;          // Certificate common name
+    signerOrganization: string;  // Certificate organization
+    signedAt: string;            // Signing timestamp (ISO 8601)
+
+    // Detailed checks
+    signatureValid: boolean;     // Cryptographic signature OK
+    integrityValid: boolean;     // Document not tampered
+    certificateValid: boolean;   // Certificate not expired
+    chainValid: boolean;         // Certificate chain OK
+    trusted: boolean;            // Root CA is trusted
+
+    // Timestamp
+    timestamped: boolean;        // Has timestamp
+    timestampValid: boolean;     // Timestamp is valid
+
+    // Issues
+    errors: string[];            // List of errors
+    warnings: string[];          // List of warnings
+  }
+}
+```
+
+**Example:**
+```javascript
+window.EasySign.verify(signedPdfBlob)
+  .then(result => {
+    const v = result.payload;
+
+    if (v.valid) {
+      console.log('✓ Signature is valid');
+      console.log('  Signed by:', v.signerName);
+      console.log('  Organization:', v.signerOrganization);
+      console.log('  Date:', new Date(v.signedAt).toLocaleString());
+
+      if (v.timestamped) {
+        console.log('  Timestamped: Yes');
+      }
+    } else {
+      console.log('✗ Signature is invalid');
+      v.errors.forEach(err => console.log('  Error:', err));
+    }
+
+    if (v.warnings.length > 0) {
+      console.log('Warnings:');
+      v.warnings.forEach(w => console.log('  -', w));
+    }
+  });
+```
+
+---
+
+## Error Handling
+
+All methods return Promises that reject with an `Error` object containing a `code` property.
+
+```typescript
+interface EasySignError extends Error {
+  code: string;  // Error code for programmatic handling
+}
+```
+
+### Error Codes
+
+| Code | Description | User Action |
+|------|-------------|-------------|
+| `TOKEN_NOT_FOUND` | Hardware token not connected | Connect token and retry |
+| `PIN_INCORRECT` | Wrong PIN entered | Re-enter correct PIN |
+| `TOKEN_LOCKED` | Token locked (too many wrong PINs) | Contact administrator |
+| `INVALID_PDF` | PDF file is corrupted or invalid | Use a valid PDF file |
+| `SIGNING_FAILED` | Signing operation failed | Check token and retry |
+| `VERIFICATION_FAILED` | Verification operation failed | Check PDF file |
+| `NATIVE_HOST_NOT_FOUND` | Native host not installed | Install native host |
+| `TIMEOUT` | Operation timed out | Retry the operation |
+| `CANCELLED` | User cancelled the operation | No action needed |
+| `ORIGIN_NOT_ALLOWED` | Website not allowed to use EasySign | N/A |
+| `INTERNAL_ERROR` | Unexpected error | Report bug |
+
+### Error Handling Example
+
+```javascript
+window.EasySign.sign(pdfBlob, options)
+  .then(result => {
+    // Success
+  })
+  .catch(err => {
+    switch (err.code) {
+      case 'TOKEN_NOT_FOUND':
+        showMessage('Please connect your hardware token');
+        break;
+
+      case 'PIN_INCORRECT':
+        showMessage('Incorrect PIN. Please try again.');
+        break;
+
+      case 'TOKEN_LOCKED':
+        showMessage('Your token is locked. Contact your IT administrator.');
+        break;
+
+      case 'CANCELLED':
+        // User cancelled - no message needed
+        break;
+
+      case 'TIMEOUT':
+        showMessage('Operation timed out. Please try again.');
+        break;
+
+      default:
+        showMessage(`Signing failed: ${err.message}`);
+        console.error('EasySign error:', err);
+    }
+  });
+```
+
+---
+
+## TypeScript Definitions
+
+For TypeScript projects, you can use these type definitions:
+
+```typescript
+declare global {
+  interface Window {
+    EasySign: {
+      isAvailable(): Promise<{
+        available: boolean;
+        tokenPresent: boolean;
+        slots: Array<{
+          index: number;
+          tokenLabel: string;
+          manufacturer: string;
+          serial: string;
+        }>;
+      }>;
+
+      sign(pdfBlob: Blob, options?: {
+        reason?: string;
+        location?: string;
+        visibleSignature?: boolean;
+        signaturePosition?: 'top_left' | 'top_right' | 'bottom_left' | 'bottom_right';
+        signaturePage?: number;
+        timestamp?: boolean;
+        timestampAuthority?: string;
+      }): Promise<{
+        blob: Blob;
+        signer_name: string;
+        signed_at: string;
+        timestamped: boolean;
+      }>;
+
+      verify(pdfBlob: Blob, options?: {
+        checkTimestamp?: boolean;
+      }): Promise<{
+        payload: {
+          valid: boolean;
+          signerName: string;
+          signerOrganization: string;
+          signedAt: string;
+          signatureValid: boolean;
+          integrityValid: boolean;
+          certificateValid: boolean;
+          chainValid: boolean;
+          trusted: boolean;
+          timestamped: boolean;
+          timestampValid: boolean;
+          errors: string[];
+          warnings: string[];
+        };
+      }>;
+    };
+  }
+}
+```
+
+Save this as `easysign.d.ts` in your project.
+
+---
+
+## Browser Compatibility
+
+| Browser | Minimum Version | Notes |
+|---------|-----------------|-------|
+| Chrome | 88+ | Full support |
+| Edge | 88+ | Chromium-based, full support |
+| Firefox | 78+ | Full support |
+| Safari | Not supported | No native messaging API |
+| Opera | 74+ | Chromium-based, should work |
+
+---
+
+## Security Considerations
+
+1. **HTTPS Only**: The extension only works on HTTPS sites (except localhost)
+2. **PIN Security**: PINs are never stored, only passed directly to the native host
+3. **Origin Validation**: Only whitelisted origins can use the API
+4. **No Key Export**: Private keys never leave the hardware token
+
+---
+
+## Rate Limiting
+
+There are no rate limits on the API, but:
+- Each `sign()` call requires user interaction (PIN entry)
+- Native host operations are sequential (one at a time)
+- Signing large PDFs may take several seconds

--- a/plugin/docs/DEVELOPMENT.md
+++ b/plugin/docs/DEVELOPMENT.md
@@ -1,0 +1,522 @@
+# EasySign Browser Extension - Development Guide
+
+This guide covers building, testing, and extending the EasySign browser extension.
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Web Application                          │
+│                   window.EasySign.sign(blob)                   │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │ window.postMessage
+┌─────────────────────────────▼───────────────────────────────────┐
+│                     Content Script (Opal)                       │
+│  - Injected into every page matching host_permissions          │
+│  - Bridges page context ↔ extension context                    │
+│  - Validates origin before forwarding messages                 │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │ chrome.runtime.sendMessage
+┌─────────────────────────────▼───────────────────────────────────┐
+│                Background Service Worker (Opal)                 │
+│  - Manages native messaging connection                         │
+│  - Opens PIN popup when signing requested                      │
+│  - Correlates requests/responses with IDs                      │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │ chrome.runtime.connectNative
+┌─────────────────────────────▼───────────────────────────────────┐
+│                   Native Messaging Host (Ruby)                  │
+│  - Stdio JSON protocol (length-prefixed)                       │
+│  - Uses EasyCodeSign gem for actual signing                    │
+│  - Accesses PKCS#11 hardware token                             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Project Structure
+
+```
+plugin/
+├── Gemfile                    # Ruby dependencies (Opal, etc.)
+├── Rakefile                   # Build tasks
+├── README.md                  # User documentation
+│
+├── src/                       # Opal Ruby source files
+│   └── easy_sign/
+│       ├── messaging.rb       # Protocol constants & helpers
+│       ├── background.rb      # Service worker
+│       ├── content.rb         # Content script
+│       ├── inject.rb          # Page-injected API
+│       └── popup.rb           # PIN popup controller
+│
+├── templates/                 # Static files
+│   ├── manifest.json          # WebExtension manifest
+│   ├── popup.html             # PIN entry popup
+│   └── popup.css              # Popup styles
+│
+├── dist/                      # Built extension (gitignored)
+│   ├── manifest.json
+│   ├── background.js
+│   ├── content.js
+│   ├── inject.js
+│   └── popup/
+│
+├── native_host/               # Native messaging host
+│   ├── src/
+│   │   ├── easy_sign_host.rb  # Main entry point
+│   │   ├── protocol.rb        # Message protocol
+│   │   └── signing_service.rb # EasyCodeSign wrapper
+│   ├── install/               # Installation scripts
+│   └── test/                  # Native host tests
+│
+├── docs/                      # Documentation
+└── test/                      # Extension tests
+```
+
+## Development Setup
+
+### Prerequisites
+
+- Ruby 3.2+
+- Bundler
+- Chrome or Firefox
+- EasyCodeSign gem installed (for native host)
+
+### Install Dependencies
+
+```bash
+cd plugin
+bundle install
+```
+
+### Build Extension
+
+```bash
+# Full build
+bundle exec rake build
+
+# Individual components
+bundle exec rake build:background
+bundle exec rake build:content
+bundle exec rake build:inject
+bundle exec rake build:popup
+bundle exec rake build:manifest
+bundle exec rake build:assets
+
+# Watch mode (auto-rebuild on changes)
+bundle exec rake watch
+
+# Clean build
+bundle exec rake clean
+```
+
+### Load Extension in Browser
+
+**Chrome:**
+1. Open `chrome://extensions`
+2. Enable "Developer mode"
+3. Click "Load unpacked"
+4. Select the `plugin/dist` directory
+5. Note the Extension ID (needed for native host)
+
+**Firefox:**
+1. Open `about:debugging#/runtime/this-firefox`
+2. Click "Load Temporary Add-on"
+3. Select `plugin/dist/manifest.json`
+
+### Install Native Host (Development)
+
+```bash
+# Set your extension ID
+export EASYSIGN_EXTENSION_ID=your_chrome_extension_id
+
+# Install for Chrome
+./native_host/install/install_chrome.sh
+
+# Or for Firefox
+export EASYSIGN_EXTENSION_ID=easysign@example.com
+./native_host/install/install_firefox.sh
+```
+
+## Opal.rb Development
+
+The extension is written in Ruby and compiled to JavaScript using [Opal](https://opalrb.com/).
+
+### Key Concepts
+
+**1. JavaScript Interop:**
+```ruby
+# backtick_javascript: true  # Required at top of file
+
+# Call JavaScript directly
+`console.log("Hello from Opal")`
+
+# Access JS objects
+`chrome.runtime.sendMessage(#{message.to_n})`
+
+# Convert Ruby to JS native object
+message.to_n
+
+# Access JS result in Ruby
+result = `document.getElementById('my-id')`
+```
+
+**2. Native Module:**
+```ruby
+require "native"
+
+# Wrap JS objects
+class ChromeStorage
+  include Native::Wrapper
+
+  def get(key)
+    promise = Promise.new
+    `chrome.storage.local.get(#{key}, function(result) {
+      #{promise.resolve(`result`)}
+    })`
+    promise
+  end
+end
+```
+
+**3. Promises:**
+```ruby
+require "promise"
+
+def async_operation
+  Promise.new do |resolve, reject|
+    # Async work...
+    resolve.call(result)
+    # Or on error:
+    reject.call(error)
+  end
+end
+```
+
+### File Structure
+
+Each Opal source file needs these magic comments:
+```ruby
+# frozen_string_literal: true
+# backtick_javascript: true
+
+require "native"
+require "easy_sign/messaging"
+
+module EasySign
+  class MyComponent
+    # ...
+  end
+end
+```
+
+## Native Messaging Protocol
+
+### Message Format
+
+Messages are JSON with a 4-byte little-endian length prefix:
+
+```
+[4 bytes: length][JSON data]
+```
+
+### Request Structure
+
+```json
+{
+  "type": "sign",
+  "requestId": "uuid-string",
+  "payload": {
+    "pdfData": "base64-encoded-pdf",
+    "pin": "1234",
+    "options": {
+      "reason": "Approved",
+      "visibleSignature": true
+    }
+  }
+}
+```
+
+### Response Structure
+
+```json
+{
+  "type": "sign_response",
+  "requestId": "uuid-string",
+  "payload": {
+    "signedPdfData": "base64-encoded-signed-pdf",
+    "signerName": "CN=John Doe",
+    "signedAt": "2025-01-06T10:30:00Z"
+  },
+  "error": null
+}
+```
+
+### Error Response
+
+```json
+{
+  "type": "error",
+  "requestId": "uuid-string",
+  "payload": null,
+  "error": {
+    "code": "PIN_INCORRECT",
+    "message": "Incorrect PIN",
+    "details": { "retriesRemaining": 2 }
+  }
+}
+```
+
+## Testing
+
+### Native Host Tests
+
+```bash
+# Run native host unit tests
+cd plugin
+ruby -I native_host/src -I ../lib native_host/test/native_host_test.rb
+```
+
+### Manual Testing
+
+1. Build and load the extension
+2. Open a test page with PDF upload
+3. Open DevTools Console
+4. Test the API:
+
+```javascript
+// Check availability
+await window.EasySign.isAvailable()
+
+// Sign a PDF (will open PIN popup)
+const input = document.querySelector('input[type=file]');
+const blob = input.files[0];
+const result = await window.EasySign.sign(blob, { visibleSignature: true });
+console.log('Signed:', result);
+```
+
+### Test Page
+
+Create a simple test page:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <title>EasySign Test</title>
+</head>
+<body>
+  <h1>EasySign Test</h1>
+
+  <h2>1. Check Availability</h2>
+  <button onclick="checkAvailability()">Check</button>
+  <pre id="availability"></pre>
+
+  <h2>2. Sign PDF</h2>
+  <input type="file" id="pdf-input" accept=".pdf">
+  <button onclick="signPdf()">Sign</button>
+  <pre id="sign-result"></pre>
+
+  <h2>3. Verify PDF</h2>
+  <input type="file" id="signed-pdf-input" accept=".pdf">
+  <button onclick="verifyPdf()">Verify</button>
+  <pre id="verify-result"></pre>
+
+  <script>
+    async function checkAvailability() {
+      try {
+        const result = await window.EasySign.isAvailable();
+        document.getElementById('availability').textContent =
+          JSON.stringify(result, null, 2);
+      } catch (e) {
+        document.getElementById('availability').textContent =
+          'Error: ' + e.message;
+      }
+    }
+
+    async function signPdf() {
+      const input = document.getElementById('pdf-input');
+      if (!input.files[0]) {
+        alert('Please select a PDF file');
+        return;
+      }
+
+      try {
+        const result = await window.EasySign.sign(input.files[0], {
+          reason: 'Test signature',
+          visibleSignature: true
+        });
+
+        document.getElementById('sign-result').textContent =
+          JSON.stringify({
+            signerName: result.signer_name,
+            signedAt: result.signed_at,
+            blobSize: result.blob.size
+          }, null, 2);
+
+        // Download signed PDF
+        const url = URL.createObjectURL(result.blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'signed.pdf';
+        a.click();
+      } catch (e) {
+        document.getElementById('sign-result').textContent =
+          'Error: ' + e.code + ' - ' + e.message;
+      }
+    }
+
+    async function verifyPdf() {
+      const input = document.getElementById('signed-pdf-input');
+      if (!input.files[0]) {
+        alert('Please select a signed PDF file');
+        return;
+      }
+
+      try {
+        const result = await window.EasySign.verify(input.files[0]);
+        document.getElementById('verify-result').textContent =
+          JSON.stringify(result.payload, null, 2);
+      } catch (e) {
+        document.getElementById('verify-result').textContent =
+          'Error: ' + e.code + ' - ' + e.message;
+      }
+    }
+  </script>
+</body>
+</html>
+```
+
+## Debugging
+
+### Extension Logs
+
+**Chrome:**
+1. Go to `chrome://extensions`
+2. Find EasySign, click "Service worker"
+3. View console logs in DevTools
+
+**Firefox:**
+1. Go to `about:debugging#/runtime/this-firefox`
+2. Find EasySign, click "Inspect"
+
+### Native Host Logs
+
+The native host writes to stderr, which browsers typically discard. For debugging:
+
+```ruby
+# In native host code
+$stderr.puts "Debug: #{message.inspect}"
+```
+
+To capture logs, modify the host to write to a file:
+
+```ruby
+# At top of easy_sign_host.rb
+LOG_FILE = File.open('/tmp/easysign.log', 'a')
+
+def log(message)
+  LOG_FILE.puts "[#{Time.now}] #{message}"
+  LOG_FILE.flush
+end
+```
+
+### Content Script Debugging
+
+Content script logs appear in the page's DevTools console:
+```ruby
+puts "Content script loaded"  # Appears in page console
+```
+
+## Extending the Extension
+
+### Adding New Message Types
+
+1. **Define in messaging.rb:**
+```ruby
+module Types
+  MY_NEW_REQUEST = "my_new_request"
+  MY_NEW_RESPONSE = "my_new_response"
+end
+```
+
+2. **Handle in background.rb:**
+```ruby
+when Messaging::Types::MY_NEW_REQUEST
+  handle_my_new_request(message, sender, send_response)
+```
+
+3. **Add to native host protocol.rb:**
+```ruby
+module Types
+  MY_NEW = "my_new"
+  MY_NEW_RESPONSE = "my_new_response"
+end
+```
+
+4. **Implement in easy_sign_host.rb:**
+```ruby
+when Protocol::Types::MY_NEW
+  process_my_new(request_id, message[:payload])
+```
+
+### Adding Configuration Options
+
+1. **Add to manifest.json:**
+```json
+"options_ui": {
+  "page": "options/options.html",
+  "open_in_tab": false
+}
+```
+
+2. **Create options page**
+3. **Store settings with chrome.storage.local**
+
+### Supporting New Token Providers
+
+1. **Add provider to EasyCodeSign gem** (main library)
+2. **Configure in native host signing_service.rb:**
+```ruby
+config.provider = ENV.fetch("EASYSIGN_PROVIDER", "safenet").to_sym
+```
+
+## Packaging for Production
+
+### Build Release
+
+```bash
+# Clean build
+bundle exec rake clean build
+
+# Create ZIP for Chrome Web Store
+cd dist
+zip -r ../easysign-chrome.zip .
+
+# Create XPI for Firefox (just a ZIP with .xpi extension)
+cd dist
+zip -r ../easysign-firefox.xpi .
+```
+
+### Package Native Host
+
+See [ruby-packer documentation](https://github.com/nicyuxuan/ruby-packer) for creating self-contained executables.
+
+```bash
+gem install rubyc
+rubyc native_host/src/easy_sign_host.rb -o native_host/dist/easy_sign_host
+```
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Run tests
+5. Submit a pull request
+
+### Code Style
+
+- Follow Ruby style guide
+- Use `frozen_string_literal: true`
+- Add `# backtick_javascript: true` for Opal files with JS interop
+- Document public methods

--- a/plugin/docs/INSTALLATION.md
+++ b/plugin/docs/INSTALLATION.md
@@ -1,0 +1,204 @@
+# EasySign Browser Extension - Installation Guide
+
+This guide covers installing the EasySign browser extension and native messaging host for end users.
+
+## Prerequisites
+
+Before installing EasySign, ensure you have:
+
+1. **Hardware Token**: SafeNet eToken (or compatible PKCS#11 device)
+2. **Token Drivers**: SafeNet Authentication Client installed
+3. **Browser**: Chrome 88+ or Firefox 78+
+
+## Quick Install
+
+### Step 1: Install Browser Extension
+
+**Chrome:**
+1. Download `easysign-chrome.zip` from the releases page
+2. Open `chrome://extensions`
+3. Enable "Developer mode" (toggle in top right)
+4. Click "Load unpacked"
+5. Select the extracted extension folder
+
+**Firefox:**
+1. Download `easysign-firefox.xpi` from the releases page
+2. Open `about:addons`
+3. Click the gear icon → "Install Add-on From File..."
+4. Select the downloaded `.xpi` file
+
+### Step 2: Install Native Host
+
+The native host enables the extension to communicate with your hardware token.
+
+**macOS:**
+```bash
+# Download and run installer
+curl -L https://github.com/mpantel/easy_code_sign/releases/latest/download/install-macos.sh | bash
+```
+
+**Linux:**
+```bash
+# Download and run installer
+curl -L https://github.com/mpantel/easy_code_sign/releases/latest/download/install-linux.sh | bash
+```
+
+**Windows:**
+1. Download `easysign-native-host-windows.exe` from releases
+2. Run the installer as Administrator
+3. Follow the installation wizard
+
+### Step 3: Verify Installation
+
+1. Open any website (e.g., `https://example.com`)
+2. Open browser Developer Tools (F12)
+3. In Console, type:
+   ```javascript
+   window.EasySign.isAvailable().then(console.log)
+   ```
+4. You should see:
+   ```javascript
+   { available: true, tokenPresent: true, slots: [...] }
+   ```
+
+## Manual Installation
+
+If automatic installation doesn't work, follow these manual steps:
+
+### Install Native Host Manually
+
+**macOS - Chrome:**
+```bash
+# Create directory
+mkdir -p ~/Library/Application\ Support/Google/Chrome/NativeMessagingHosts
+
+# Copy manifest (edit paths first!)
+cat > ~/Library/Application\ Support/Google/Chrome/NativeMessagingHosts/com.easysign.host.json << 'EOF'
+{
+  "name": "com.easysign.host",
+  "description": "EasySign PDF Signing Native Host",
+  "path": "/path/to/easy_sign_host",
+  "type": "stdio",
+  "allowed_origins": ["chrome-extension://YOUR_EXTENSION_ID/"]
+}
+EOF
+```
+
+**macOS - Firefox:**
+```bash
+mkdir -p ~/Library/Application\ Support/Mozilla/NativeMessagingHosts
+
+cat > ~/Library/Application\ Support/Mozilla/NativeMessagingHosts/com.easysign.host.json << 'EOF'
+{
+  "name": "com.easysign.host",
+  "description": "EasySign PDF Signing Native Host",
+  "path": "/path/to/easy_sign_host",
+  "type": "stdio",
+  "allowed_extensions": ["easysign@example.com"]
+}
+EOF
+```
+
+**Linux - Chrome:**
+```bash
+mkdir -p ~/.config/google-chrome/NativeMessagingHosts
+# Copy manifest as above
+```
+
+**Linux - Firefox:**
+```bash
+mkdir -p ~/.mozilla/native-messaging-hosts
+# Copy manifest as above
+```
+
+**Windows:**
+1. Copy `easy_sign_host.exe` to `C:\Program Files\EasySign\`
+2. Create registry key:
+   - Chrome: `HKCU\Software\Google\Chrome\NativeMessagingHosts\com.easysign.host`
+   - Firefox: `HKCU\Software\Mozilla\NativeMessagingHosts\com.easysign.host`
+3. Set default value to manifest path
+
+## Troubleshooting
+
+### Extension Not Working
+
+**"Native host not found" error:**
+- Verify the native host manifest is in the correct location
+- Check that the `path` in the manifest points to the actual executable
+- Ensure the executable has execute permissions (`chmod +x`)
+
+**"Token not found" error:**
+- Check that your hardware token is connected
+- Verify SafeNet drivers are installed
+- Try running `pkcs11-tool --list-slots` to verify token visibility
+
+**Extension icon is grayed out:**
+- The extension may be disabled - check `chrome://extensions`
+- Try removing and re-adding the extension
+
+### Permission Issues
+
+**macOS Gatekeeper blocks native host:**
+```bash
+# Allow the native host to run
+xattr -d com.apple.quarantine /path/to/easy_sign_host
+```
+
+**Linux permission denied:**
+```bash
+# Ensure executable permission
+chmod +x /path/to/easy_sign_host
+```
+
+### Getting Extension ID
+
+**Chrome:**
+1. Go to `chrome://extensions`
+2. Enable "Developer mode"
+3. The ID is shown under the extension name
+
+**Firefox:**
+1. Go to `about:debugging#/runtime/this-firefox`
+2. Find EasySign in the list
+3. The ID is shown as "Extension ID"
+
+## Updating
+
+### Update Extension
+- Chrome: Will auto-update from Web Store
+- Firefox: Will auto-update from Add-ons
+
+### Update Native Host
+Run the installer again - it will replace the existing installation.
+
+## Uninstalling
+
+### Remove Extension
+- Chrome: Go to `chrome://extensions`, click "Remove"
+- Firefox: Go to `about:addons`, click "Remove"
+
+### Remove Native Host
+
+**macOS/Linux:**
+```bash
+# Chrome
+rm ~/Library/Application\ Support/Google/Chrome/NativeMessagingHosts/com.easysign.host.json
+
+# Firefox
+rm ~/Library/Application\ Support/Mozilla/NativeMessagingHosts/com.easysign.host.json
+
+# Remove executable
+rm /path/to/easy_sign_host
+```
+
+**Windows:**
+Run the uninstaller or manually delete:
+- Registry keys under `NativeMessagingHosts`
+- `C:\Program Files\EasySign\` folder
+
+## Security Notes
+
+- The extension only activates on HTTPS sites (and localhost for development)
+- Your PIN is never stored - it's entered fresh each time you sign
+- The native host runs only when needed and exits after signing
+- Private keys never leave your hardware token

--- a/plugin/native_host/build/Rakefile
+++ b/plugin/native_host/build/Rakefile
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+DIST_DIR = File.expand_path("../dist", __dir__)
+SRC_DIR = File.expand_path("../src", __dir__)
+ROOT_DIR = File.expand_path("../../..", __dir__)
+
+desc "Build native host for current platform"
+task build: :clean do
+  mkdir_p DIST_DIR
+
+  # For development, create a wrapper script that uses Ruby
+  create_dev_wrapper
+end
+
+desc "Package native host as self-contained executable"
+task package: :clean do
+  mkdir_p DIST_DIR
+
+  # Check for ruby-packer
+  unless system("which rubyc > /dev/null 2>&1")
+    puts "ruby-packer (rubyc) not found. Install with: gem install rubyc"
+    puts "Falling back to development wrapper..."
+    create_dev_wrapper
+    exit 0
+  end
+
+  # Package with ruby-packer
+  platform = case RUBY_PLATFORM
+             when /darwin/ then "macos"
+             when /linux/ then "linux"
+             when /mingw|mswin/ then "windows"
+             else "unknown"
+             end
+
+  output_name = platform == "windows" ? "easy_sign_host.exe" : "easy_sign_host_#{platform}"
+  output_path = File.join(DIST_DIR, output_name)
+
+  puts "Packaging native host for #{platform}..."
+
+  # Create a temporary entry point that requires all dependencies
+  entry_point = File.join(SRC_DIR, "easy_sign_host.rb")
+
+  cmd = [
+    "rubyc",
+    entry_point,
+    "-o", output_path,
+    "--add-dependency", "easy_code_sign"
+  ]
+
+  unless system(*cmd)
+    puts "Packaging failed. Check ruby-packer installation."
+    exit 1
+  end
+
+  puts "Created: #{output_path}"
+end
+
+desc "Clean build artifacts"
+task :clean do
+  FileUtils.rm_rf(Dir.glob("#{DIST_DIR}/*"))
+end
+
+desc "Run native host tests"
+task :test do
+  sh "ruby -I#{SRC_DIR} -I#{ROOT_DIR}/lib #{SRC_DIR}/../test/native_host_test.rb"
+end
+
+private
+
+def create_dev_wrapper
+  # Create a shell wrapper for development that uses system Ruby
+  wrapper_path = File.join(DIST_DIR, "easy_sign_host")
+  host_script = File.join(SRC_DIR, "easy_sign_host.rb")
+
+  File.write(wrapper_path, <<~BASH)
+    #!/bin/bash
+    # Development wrapper for EasySign Native Host
+    # Uses system Ruby and requires easy_code_sign gem to be installed
+
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    HOST_SCRIPT="#{host_script}"
+
+    exec ruby "$HOST_SCRIPT" "$@"
+  BASH
+
+  FileUtils.chmod(0o755, wrapper_path)
+  puts "Created development wrapper: #{wrapper_path}"
+end

--- a/plugin/native_host/install/com.easysign.host.json
+++ b/plugin/native_host/install/com.easysign.host.json
@@ -1,0 +1,9 @@
+{
+  "name": "com.easysign.host",
+  "description": "EasySign PDF Signing Native Host",
+  "path": "{{HOST_PATH}}",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://{{EXTENSION_ID}}/"
+  ]
+}

--- a/plugin/native_host/install/install_chrome.sh
+++ b/plugin/native_host/install/install_chrome.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Install EasySign Native Messaging Host for Chrome/Chromium
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOST_NAME="com.easysign.host"
+
+# Detect host executable path
+if [ -f "$SCRIPT_DIR/../dist/easy_sign_host" ]; then
+  # Use packaged binary
+  HOST_PATH="$SCRIPT_DIR/../dist/easy_sign_host"
+elif [ -f "$SCRIPT_DIR/../src/easy_sign_host.rb" ]; then
+  # Use Ruby script directly (development mode)
+  HOST_PATH="$SCRIPT_DIR/../src/easy_sign_host.rb"
+  chmod +x "$HOST_PATH"
+else
+  echo "Error: Native host executable not found"
+  exit 1
+fi
+
+HOST_PATH="$(cd "$(dirname "$HOST_PATH")" && pwd)/$(basename "$HOST_PATH")"
+
+# Get extension ID (can be overridden)
+EXTENSION_ID="${EASYSIGN_EXTENSION_ID:-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx}"
+
+# Determine manifest directory based on OS
+case "$(uname -s)" in
+  Darwin)
+    # macOS
+    if [ "$USER" = "root" ]; then
+      MANIFEST_DIR="/Library/Google/Chrome/NativeMessagingHosts"
+    else
+      MANIFEST_DIR="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+    fi
+    ;;
+  Linux)
+    # Linux
+    if [ "$USER" = "root" ]; then
+      MANIFEST_DIR="/etc/opt/chrome/native-messaging-hosts"
+    else
+      MANIFEST_DIR="$HOME/.config/google-chrome/NativeMessagingHosts"
+    fi
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    # Windows (Git Bash, MSYS2, Cygwin)
+    MANIFEST_DIR="$LOCALAPPDATA/Google/Chrome/User Data/NativeMessagingHosts"
+    ;;
+  *)
+    echo "Error: Unsupported operating system"
+    exit 1
+    ;;
+esac
+
+# Create manifest directory if it doesn't exist
+mkdir -p "$MANIFEST_DIR"
+
+# Generate manifest
+MANIFEST_PATH="$MANIFEST_DIR/$HOST_NAME.json"
+
+cat > "$MANIFEST_PATH" << EOF
+{
+  "name": "$HOST_NAME",
+  "description": "EasySign PDF Signing Native Host",
+  "path": "$HOST_PATH",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://$EXTENSION_ID/"
+  ]
+}
+EOF
+
+echo "EasySign Native Messaging Host installed for Chrome"
+echo "  Manifest: $MANIFEST_PATH"
+echo "  Host: $HOST_PATH"
+echo ""
+echo "NOTE: Update the extension ID in the manifest if needed:"
+echo "  Current: $EXTENSION_ID"
+echo ""
+echo "To update, run:"
+echo "  EASYSIGN_EXTENSION_ID=your_extension_id $0"

--- a/plugin/native_host/install/install_firefox.sh
+++ b/plugin/native_host/install/install_firefox.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Install EasySign Native Messaging Host for Firefox
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOST_NAME="com.easysign.host"
+
+# Detect host executable path
+if [ -f "$SCRIPT_DIR/../dist/easy_sign_host" ]; then
+  # Use packaged binary
+  HOST_PATH="$SCRIPT_DIR/../dist/easy_sign_host"
+elif [ -f "$SCRIPT_DIR/../src/easy_sign_host.rb" ]; then
+  # Use Ruby script directly (development mode)
+  HOST_PATH="$SCRIPT_DIR/../src/easy_sign_host.rb"
+  chmod +x "$HOST_PATH"
+else
+  echo "Error: Native host executable not found"
+  exit 1
+fi
+
+HOST_PATH="$(cd "$(dirname "$HOST_PATH")" && pwd)/$(basename "$HOST_PATH")"
+
+# Get extension ID (Firefox uses email-style IDs)
+EXTENSION_ID="${EASYSIGN_EXTENSION_ID:-easysign@example.com}"
+
+# Determine manifest directory based on OS
+case "$(uname -s)" in
+  Darwin)
+    # macOS
+    if [ "$USER" = "root" ]; then
+      MANIFEST_DIR="/Library/Application Support/Mozilla/NativeMessagingHosts"
+    else
+      MANIFEST_DIR="$HOME/Library/Application Support/Mozilla/NativeMessagingHosts"
+    fi
+    ;;
+  Linux)
+    # Linux
+    if [ "$USER" = "root" ]; then
+      MANIFEST_DIR="/usr/lib/mozilla/native-messaging-hosts"
+    else
+      MANIFEST_DIR="$HOME/.mozilla/native-messaging-hosts"
+    fi
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    # Windows (Git Bash, MSYS2, Cygwin)
+    MANIFEST_DIR="$APPDATA/Mozilla/NativeMessagingHosts"
+    ;;
+  *)
+    echo "Error: Unsupported operating system"
+    exit 1
+    ;;
+esac
+
+# Create manifest directory if it doesn't exist
+mkdir -p "$MANIFEST_DIR"
+
+# Generate manifest (Firefox uses allowed_extensions instead of allowed_origins)
+MANIFEST_PATH="$MANIFEST_DIR/$HOST_NAME.json"
+
+cat > "$MANIFEST_PATH" << EOF
+{
+  "name": "$HOST_NAME",
+  "description": "EasySign PDF Signing Native Host",
+  "path": "$HOST_PATH",
+  "type": "stdio",
+  "allowed_extensions": [
+    "$EXTENSION_ID"
+  ]
+}
+EOF
+
+echo "EasySign Native Messaging Host installed for Firefox"
+echo "  Manifest: $MANIFEST_PATH"
+echo "  Host: $HOST_PATH"
+echo ""
+echo "NOTE: Update the extension ID in the manifest if needed:"
+echo "  Current: $EXTENSION_ID"
+echo ""
+echo "To update, run:"
+echo "  EASYSIGN_EXTENSION_ID=your_extension_id $0"

--- a/plugin/native_host/src/easy_sign_host.rb
+++ b/plugin/native_host/src/easy_sign_host.rb
@@ -1,0 +1,158 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# EasySign Native Messaging Host
+# Communicates with browser extension via stdin/stdout using length-prefixed JSON
+
+require "json"
+
+# Add lib to load path for development
+$LOAD_PATH.unshift(File.expand_path("../../../lib", __dir__))
+$LOAD_PATH.unshift(__dir__)
+
+require "protocol"
+require "signing_service"
+
+module EasySign
+  # Native Messaging Host for browser extension communication
+  class NativeHost
+    MAX_MESSAGE_SIZE = 1024 * 1024 # 1MB limit
+
+    def initialize
+      @signing_service = SigningService.new
+
+      # Ensure binary mode for stdin/stdout
+      $stdin.binmode
+      $stdout.binmode
+
+      # Disable stdout buffering
+      $stdout.sync = true
+    end
+
+    # Main loop - read and process messages
+    def run
+      loop do
+        message = read_message
+        break unless message
+
+        response = process_message(message)
+        write_message(response)
+      end
+    rescue Interrupt
+      # Clean exit on Ctrl+C (shouldn't happen in normal use)
+      exit 0
+    rescue StandardError => e
+      # Log error but don't crash - browser will handle disconnect
+      write_message(Protocol.error_response(nil, Protocol::ErrorCodes::INTERNAL_ERROR, e.message))
+    end
+
+    private
+
+    # Read a native messaging message from stdin
+    # Format: 4-byte length (little-endian uint32) + JSON data
+    def read_message
+      # Read 4-byte length prefix
+      length_bytes = $stdin.read(4)
+      return nil unless length_bytes && length_bytes.bytesize == 4
+
+      # Unpack as little-endian unsigned 32-bit integer
+      length = length_bytes.unpack1("V")
+
+      # Validate length
+      return nil if length.zero? || length > MAX_MESSAGE_SIZE
+
+      # Read JSON data
+      json_data = $stdin.read(length)
+      return nil unless json_data && json_data.bytesize == length
+
+      JSON.parse(json_data, symbolize_names: true)
+    rescue JSON::ParserError => e
+      # Return error for invalid JSON
+      { type: "invalid", error: e.message }
+    end
+
+    # Write a native messaging message to stdout
+    # Format: 4-byte length (little-endian uint32) + JSON data
+    def write_message(message)
+      json = message.to_json
+      length = [json.bytesize].pack("V") # Little-endian uint32
+
+      $stdout.write(length)
+      $stdout.write(json)
+      $stdout.flush
+    end
+
+    # Process an incoming message and return response
+    def process_message(message)
+      request_id = message[:requestId] || message[:request_id]
+      type = message[:type]
+
+      case type
+      when Protocol::Types::SIGN
+        process_sign(request_id, message[:payload])
+      when Protocol::Types::VERIFY
+        process_verify(request_id, message[:payload])
+      when Protocol::Types::CHECK_AVAILABILITY
+        process_check_availability(request_id)
+      when "invalid"
+        Protocol.error_response(request_id, Protocol::ErrorCodes::INVALID_MESSAGE, message[:error])
+      else
+        Protocol.error_response(request_id, Protocol::ErrorCodes::INVALID_MESSAGE, "Unknown message type: #{type}")
+      end
+    end
+
+    def process_sign(request_id, payload)
+      result = @signing_service.sign(
+        pdf_data: payload[:pdfData],
+        pin: payload[:pin],
+        options: payload[:options] || {}
+      )
+
+      Protocol.sign_response(request_id, result)
+    rescue EasyCodeSign::PinError => e
+      Protocol.error_response(
+        request_id,
+        Protocol::ErrorCodes::PIN_INCORRECT,
+        e.message,
+        { retriesRemaining: e.respond_to?(:retries_remaining) ? e.retries_remaining : nil }
+      )
+    rescue EasyCodeSign::TokenNotFoundError => e
+      Protocol.error_response(request_id, Protocol::ErrorCodes::TOKEN_NOT_FOUND, e.message)
+    rescue EasyCodeSign::TokenLockedError => e
+      Protocol.error_response(request_id, Protocol::ErrorCodes::TOKEN_LOCKED, e.message)
+    rescue EasyCodeSign::InvalidPdfError => e
+      Protocol.error_response(request_id, Protocol::ErrorCodes::INVALID_PDF, e.message)
+    rescue EasyCodeSign::Error => e
+      Protocol.error_response(request_id, Protocol::ErrorCodes::SIGNING_FAILED, e.message)
+    rescue StandardError => e
+      Protocol.error_response(request_id, Protocol::ErrorCodes::INTERNAL_ERROR, e.message)
+    end
+
+    def process_verify(request_id, payload)
+      result = @signing_service.verify(
+        pdf_data: payload[:pdfData],
+        check_timestamp: payload[:checkTimestamp] != false
+      )
+
+      Protocol.verify_response(request_id, result)
+    rescue EasyCodeSign::InvalidPdfError => e
+      Protocol.error_response(request_id, Protocol::ErrorCodes::INVALID_PDF, e.message)
+    rescue EasyCodeSign::Error => e
+      Protocol.error_response(request_id, Protocol::ErrorCodes::VERIFICATION_FAILED, e.message)
+    rescue StandardError => e
+      Protocol.error_response(request_id, Protocol::ErrorCodes::INTERNAL_ERROR, e.message)
+    end
+
+    def process_check_availability(request_id)
+      result = @signing_service.check_availability
+      Protocol.availability_response(request_id, result)
+    rescue StandardError => e
+      Protocol.error_response(request_id, Protocol::ErrorCodes::INTERNAL_ERROR, e.message)
+    end
+  end
+end
+
+# Entry point
+if __FILE__ == $PROGRAM_NAME
+  EasySign::NativeHost.new.run
+end

--- a/plugin/native_host/src/protocol.rb
+++ b/plugin/native_host/src/protocol.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# Native Messaging Protocol definitions
+module EasySign
+  module Protocol
+    # Message types
+    module Types
+      SIGN = "sign"
+      VERIFY = "verify"
+      CHECK_AVAILABILITY = "check_availability"
+
+      SIGN_RESPONSE = "sign_response"
+      VERIFY_RESPONSE = "verify_response"
+      AVAILABILITY_RESPONSE = "availability_response"
+      ERROR = "error"
+    end
+
+    # Error codes
+    module ErrorCodes
+      TOKEN_NOT_FOUND = "TOKEN_NOT_FOUND"
+      PIN_INCORRECT = "PIN_INCORRECT"
+      TOKEN_LOCKED = "TOKEN_LOCKED"
+      INVALID_PDF = "INVALID_PDF"
+      SIGNING_FAILED = "SIGNING_FAILED"
+      VERIFICATION_FAILED = "VERIFICATION_FAILED"
+      INVALID_MESSAGE = "INVALID_MESSAGE"
+      INTERNAL_ERROR = "INTERNAL_ERROR"
+    end
+
+    class << self
+      # Create a success response
+      def success_response(request_id, type, payload)
+        {
+          type: type,
+          requestId: request_id,
+          payload: payload,
+          error: nil
+        }
+      end
+
+      # Create an error response
+      def error_response(request_id, code, message, details = nil)
+        {
+          type: Types::ERROR,
+          requestId: request_id,
+          payload: nil,
+          error: {
+            code: code,
+            message: message,
+            details: details
+          }.compact
+        }
+      end
+
+      # Create sign response
+      def sign_response(request_id, result)
+        success_response(request_id, Types::SIGN_RESPONSE, {
+          signedPdfData: result[:signed_pdf_data],
+          signerName: result[:signer_name],
+          signedAt: result[:signed_at]&.iso8601,
+          timestamped: result[:timestamped] || false
+        })
+      end
+
+      # Create verify response
+      def verify_response(request_id, result)
+        success_response(request_id, Types::VERIFY_RESPONSE, {
+          valid: result[:valid],
+          signerName: result[:signer_name],
+          signerOrganization: result[:signer_organization],
+          signedAt: result[:signed_at]&.iso8601,
+          signatureValid: result[:signature_valid],
+          integrityValid: result[:integrity_valid],
+          certificateValid: result[:certificate_valid],
+          chainValid: result[:chain_valid],
+          trusted: result[:trusted],
+          timestamped: result[:timestamped],
+          timestampValid: result[:timestamp_valid],
+          errors: result[:errors] || [],
+          warnings: result[:warnings] || []
+        })
+      end
+
+      # Create availability response
+      def availability_response(request_id, result)
+        success_response(request_id, Types::AVAILABILITY_RESPONSE, {
+          available: result[:available],
+          tokenPresent: result[:token_present],
+          slots: result[:slots]&.map do |slot|
+            {
+              index: slot[:index],
+              tokenLabel: slot[:token_label],
+              manufacturer: slot[:manufacturer],
+              serial: slot[:serial]
+            }
+          end
+        })
+      end
+    end
+  end
+end

--- a/plugin/native_host/src/signing_service.rb
+++ b/plugin/native_host/src/signing_service.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "base64"
+require "tempfile"
+require "easy_code_sign"
+
+module EasySign
+  # Service that wraps EasyCodeSign gem for browser extension use
+  class SigningService
+    def initialize
+      configure_easy_code_sign
+    end
+
+    # Sign a PDF document
+    # @param pdf_data [String] Base64-encoded PDF content
+    # @param pin [String] Token PIN
+    # @param options [Hash] Signing options
+    # @return [Hash] Result with signed PDF data
+    def sign(pdf_data:, pin:, options: {})
+      # Decode PDF from Base64
+      pdf_bytes = Base64.strict_decode64(pdf_data)
+
+      # Write to temp file
+      input_file = Tempfile.new(["input", ".pdf"], binmode: true)
+      output_file = Tempfile.new(["signed", ".pdf"], binmode: true)
+
+      begin
+        input_file.write(pdf_bytes)
+        input_file.close
+
+        # Build signing options
+        sign_opts = build_sign_options(options).merge(
+          pin: pin,
+          output_path: output_file.path
+        )
+
+        # Sign using EasyCodeSign
+        result = EasyCodeSign.sign(input_file.path, **sign_opts)
+
+        # Read signed PDF and encode as Base64
+        signed_bytes = File.binread(output_file.path)
+        signed_base64 = Base64.strict_encode64(signed_bytes)
+
+        {
+          signed_pdf_data: signed_base64,
+          signer_name: result.signer_name,
+          signed_at: result.signed_at,
+          timestamped: result.timestamped?
+        }
+      ensure
+        input_file.unlink
+        output_file.close
+        output_file.unlink
+      end
+    end
+
+    # Verify a signed PDF document
+    # @param pdf_data [String] Base64-encoded PDF content
+    # @param check_timestamp [Boolean] Whether to verify timestamp
+    # @return [Hash] Verification result
+    def verify(pdf_data:, check_timestamp: true)
+      # Decode PDF from Base64
+      pdf_bytes = Base64.strict_decode64(pdf_data)
+
+      # Write to temp file
+      temp_file = Tempfile.new(["verify", ".pdf"], binmode: true)
+
+      begin
+        temp_file.write(pdf_bytes)
+        temp_file.close
+
+        # Verify using EasyCodeSign
+        result = EasyCodeSign.verify(temp_file.path, check_timestamp: check_timestamp)
+
+        {
+          valid: result.valid?,
+          signer_name: result.signer_name,
+          signer_organization: result.signer_organization,
+          signed_at: result.timestamp,
+          signature_valid: result.signature_valid?,
+          integrity_valid: result.integrity_valid?,
+          certificate_valid: result.certificate_valid?,
+          chain_valid: result.chain_valid?,
+          trusted: result.trusted?,
+          timestamped: result.timestamped?,
+          timestamp_valid: result.timestamp_valid?,
+          errors: result.errors,
+          warnings: result.warnings
+        }
+      ensure
+        temp_file.unlink
+      end
+    end
+
+    # Check if signing is available (token connected, etc.)
+    # @return [Hash] Availability status
+    def check_availability
+      begin
+        slots = EasyCodeSign.list_slots
+
+        # Check if any slot has a token present
+        token_present = slots.any? { |s| s[:token_present] }
+
+        {
+          available: true,
+          token_present: token_present,
+          slots: slots.map do |slot|
+            {
+              index: slot[:index],
+              token_label: slot[:token_label],
+              manufacturer: slot[:manufacturer],
+              serial: slot[:serial]
+            }
+          end
+        }
+      rescue EasyCodeSign::Pkcs11LibraryError, EasyCodeSign::TokenNotFoundError => e
+        {
+          available: false,
+          token_present: false,
+          error: e.message,
+          slots: []
+        }
+      end
+    end
+
+    private
+
+    def configure_easy_code_sign
+      # Use default configuration - can be customized via env vars or config file
+      EasyCodeSign.configure do |config|
+        # Provider can be set via env var
+        config.provider = ENV.fetch("EASYSIGN_PROVIDER", "safenet").to_sym
+
+        # PKCS#11 library path (auto-detected if not set)
+        config.pkcs11_library = ENV["EASYSIGN_PKCS11_LIBRARY"] if ENV["EASYSIGN_PKCS11_LIBRARY"]
+
+        # Timestamp authority
+        config.timestamp_authority = ENV.fetch("EASYSIGN_TSA_URL", "http://timestamp.digicert.com")
+
+        # Network timeout
+        config.network_timeout = ENV.fetch("EASYSIGN_TIMEOUT", 30).to_i
+      end
+    end
+
+    def build_sign_options(options)
+      opts = {}
+
+      # Timestamp
+      opts[:timestamp] = options["timestamp"] || options[:timestamp] || false
+      if options["timestampAuthority"] || options[:timestamp_authority]
+        EasyCodeSign.configuration.timestamp_authority =
+          options["timestampAuthority"] || options[:timestamp_authority]
+      end
+
+      # Visible signature
+      opts[:visible_signature] = options["visibleSignature"] || options[:visible_signature] || false
+      opts[:signature_page] = options["signaturePage"] || options[:signature_page] || 1
+      opts[:signature_position] = (options["signaturePosition"] || options[:signature_position] || "bottom_right").to_sym
+
+      # Signature metadata
+      opts[:signature_reason] = options["reason"] || options[:reason]
+      opts[:signature_location] = options["location"] || options[:location]
+
+      opts.compact
+    end
+  end
+end

--- a/plugin/native_host/test/native_host_test.rb
+++ b/plugin/native_host/test/native_host_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "json"
+
+# Add paths for testing
+$LOAD_PATH.unshift(File.expand_path("../../src", __dir__))
+$LOAD_PATH.unshift(File.expand_path("../../../lib", __dir__))
+
+require "protocol"
+
+class ProtocolTest < Minitest::Test
+  def test_sign_response_creates_correct_structure
+    result = {
+      signed_pdf_data: "base64data",
+      signer_name: "CN=Test User",
+      signed_at: Time.now,
+      timestamped: true
+    }
+
+    response = EasySign::Protocol.sign_response("req-123", result)
+
+    assert_equal "sign_response", response[:type]
+    assert_equal "req-123", response[:requestId]
+    assert_nil response[:error]
+    assert_equal "base64data", response[:payload][:signedPdfData]
+    assert_equal "CN=Test User", response[:payload][:signerName]
+    assert response[:payload][:timestamped]
+  end
+
+  def test_error_response_creates_correct_structure
+    response = EasySign::Protocol.error_response(
+      "req-456",
+      EasySign::Protocol::ErrorCodes::PIN_INCORRECT,
+      "Wrong PIN",
+      { retriesRemaining: 2 }
+    )
+
+    assert_equal "error", response[:type]
+    assert_equal "req-456", response[:requestId]
+    assert_nil response[:payload]
+    assert_equal "PIN_INCORRECT", response[:error][:code]
+    assert_equal "Wrong PIN", response[:error][:message]
+    assert_equal 2, response[:error][:details][:retriesRemaining]
+  end
+
+  def test_verify_response_creates_correct_structure
+    result = {
+      valid: true,
+      signer_name: "CN=Test User",
+      signature_valid: true,
+      integrity_valid: true,
+      certificate_valid: true,
+      chain_valid: true,
+      trusted: true,
+      timestamped: false,
+      errors: [],
+      warnings: []
+    }
+
+    response = EasySign::Protocol.verify_response("req-789", result)
+
+    assert_equal "verify_response", response[:type]
+    assert_equal "req-789", response[:requestId]
+    assert response[:payload][:valid]
+    assert response[:payload][:signatureValid]
+    assert_empty response[:payload][:errors]
+  end
+
+  def test_availability_response_creates_correct_structure
+    result = {
+      available: true,
+      token_present: true,
+      slots: [
+        { index: 0, token_label: "Token1", manufacturer: "SafeNet", serial: "12345" }
+      ]
+    }
+
+    response = EasySign::Protocol.availability_response("req-000", result)
+
+    assert_equal "availability_response", response[:type]
+    assert response[:payload][:available]
+    assert response[:payload][:tokenPresent]
+    assert_equal 1, response[:payload][:slots].length
+    assert_equal "Token1", response[:payload][:slots][0][:tokenLabel]
+  end
+end
+
+class MessageFormatTest < Minitest::Test
+  def test_native_message_encoding
+    message = { type: "test", requestId: "123" }
+    json = message.to_json
+    length = [json.bytesize].pack("V")
+
+    # Verify length prefix format
+    assert_equal 4, length.bytesize
+    assert_equal json.bytesize, length.unpack1("V")
+  end
+
+  def test_native_message_decoding
+    message = { type: "sign", requestId: "abc", payload: { pdfData: "test" } }
+    json = message.to_json
+    length_bytes = [json.bytesize].pack("V")
+
+    # Simulate reading
+    decoded_length = length_bytes.unpack1("V")
+    assert_equal json.bytesize, decoded_length
+
+    decoded = JSON.parse(json, symbolize_names: true)
+    assert_equal "sign", decoded[:type]
+    assert_equal "abc", decoded[:requestId]
+  end
+end

--- a/plugin/src/easy_sign/background.rb
+++ b/plugin/src/easy_sign/background.rb
@@ -1,0 +1,323 @@
+# frozen_string_literal: true
+# backtick_javascript: true
+
+require "native"
+require "easy_sign/messaging"
+
+# Background service worker for EasySign browser extension
+# Handles communication between content scripts and native messaging host
+module EasySign
+  class Background
+    NATIVE_HOST_NAME = "com.easysign.host"
+
+    def initialize
+      @native_port = nil
+      @pending_requests = {}
+      @current_signing_request = nil
+      setup_listeners
+      puts "EasySign background service worker initialized"
+    end
+
+    def setup_listeners
+      # Listen for messages from content scripts
+      `chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+        #{handle_message(`message`, `sender`, `sendResponse`)}
+        return true; // Keep channel open for async response
+      })`
+
+      # Listen for connections (for popup communication)
+      `chrome.runtime.onConnect.addListener((port) => {
+        #{handle_port_connect(`port`)}
+      })`
+    end
+
+    def handle_message(message, sender, send_response)
+      type = message[:type] || `message.type`
+      request_id = message[:request_id] || `message.requestId` || `message.request_id`
+
+      case type
+      when Messaging::Types::SIGN_REQUEST
+        handle_sign_request(message, sender, send_response)
+      when Messaging::Types::VERIFY_REQUEST
+        handle_verify_request(message, sender, send_response)
+      when Messaging::Types::AVAILABILITY_REQUEST
+        handle_availability_request(send_response)
+      when Messaging::Types::CANCEL_REQUEST
+        handle_cancel_request(request_id, send_response)
+      else
+        send_error(send_response, request_id, Messaging::ErrorCodes::INTERNAL_ERROR,
+                   "Unknown message type: #{type}")
+      end
+    end
+
+    def handle_port_connect(port)
+      port_name = `port.name`
+
+      case port_name
+      when "popup"
+        setup_popup_port(port)
+      end
+    end
+
+    def setup_popup_port(port)
+      @popup_port = port
+
+      `port.onMessage.addListener((message) => {
+        #{handle_popup_message(`message`)}
+      })`
+
+      `port.onDisconnect.addListener(() => {
+        #{handle_popup_disconnect}
+      })`
+    end
+
+    def handle_popup_message(message)
+      type = message[:type] || `message.type`
+
+      case type
+      when Messaging::Types::PIN_SUBMITTED
+        pin = message[:pin] || `message.pin`
+        complete_signing_with_pin(pin)
+      when Messaging::Types::PIN_CANCELLED
+        cancel_current_signing
+      when Messaging::Types::POPUP_READY
+        send_signing_context_to_popup
+      end
+    end
+
+    def handle_popup_disconnect
+      @popup_port = nil
+      # If popup closes without submitting PIN, cancel the operation
+      cancel_current_signing if @current_signing_request
+    end
+
+    def handle_sign_request(message, sender, send_response)
+      payload = message[:payload] || `message.payload`
+
+      # Validate origin
+      origin = `sender.origin || sender.url`
+      unless origin_allowed?(origin)
+        send_error(send_response, message[:request_id],
+                   Messaging::ErrorCodes::ORIGIN_NOT_ALLOWED,
+                   "Origin not allowed: #{origin}")
+        return
+      end
+
+      # Store the request for completion after PIN entry
+      @current_signing_request = {
+        message: message,
+        sender: sender,
+        send_response: send_response,
+        payload: payload
+      }
+
+      # Open popup for PIN entry
+      open_pin_popup
+    end
+
+    def handle_verify_request(message, sender, send_response)
+      payload = message[:payload] || `message.payload`
+
+      # Verification doesn't need PIN, send directly to native host
+      ensure_native_connection do |error|
+        if error
+          send_error(send_response, message[:request_id],
+                     Messaging::ErrorCodes::NATIVE_HOST_NOT_FOUND, error)
+          return
+        end
+
+        native_message = {
+          type: "verify",
+          requestId: message[:request_id] || `message.requestId`,
+          payload: {
+            pdfData: payload[:pdf_data] || `payload.pdfData`,
+            checkTimestamp: payload[:check_timestamp] != false
+          }
+        }
+
+        send_to_native(native_message, send_response)
+      end
+    end
+
+    def handle_availability_request(send_response)
+      ensure_native_connection do |error|
+        if error
+          # Native host not available, but extension is
+          response = Messaging.create_response(
+            nil,
+            Messaging::Types::AVAILABILITY_RESPONSE,
+            { available: false, nativeHostInstalled: false, error: error }
+          )
+          `sendResponse(#{response.to_n})`
+          return
+        end
+
+        native_message = { type: "check_availability", requestId: Messaging.generate_request_id }
+        send_to_native(native_message, send_response)
+      end
+    end
+
+    def handle_cancel_request(request_id, send_response)
+      if @current_signing_request && @current_signing_request[:message][:request_id] == request_id
+        cancel_current_signing
+      end
+
+      response = Messaging.create_response(request_id, "cancel_response", { cancelled: true })
+      `sendResponse(#{response.to_n})`
+    end
+
+    def complete_signing_with_pin(pin)
+      return unless @current_signing_request
+
+      request = @current_signing_request
+      message = request[:message]
+      payload = request[:payload]
+      send_response = request[:send_response]
+
+      ensure_native_connection do |error|
+        if error
+          send_error(send_response, message[:request_id],
+                     Messaging::ErrorCodes::NATIVE_HOST_NOT_FOUND, error)
+          @current_signing_request = nil
+          return
+        end
+
+        native_message = {
+          type: "sign",
+          requestId: message[:request_id] || `message.requestId`,
+          payload: {
+            pdfData: payload[:pdf_data] || `payload.pdfData`,
+            pin: pin,
+            options: payload[:options] || `payload.options` || {}
+          }
+        }
+
+        send_to_native(native_message, send_response)
+        @current_signing_request = nil
+      end
+    end
+
+    def cancel_current_signing
+      return unless @current_signing_request
+
+      request = @current_signing_request
+      send_response = request[:send_response]
+      request_id = request[:message][:request_id]
+
+      send_error(send_response, request_id, Messaging::ErrorCodes::CANCELLED, "Operation cancelled by user")
+      @current_signing_request = nil
+    end
+
+    def send_signing_context_to_popup
+      return unless @popup_port && @current_signing_request
+
+      context = {
+        type: "signing_context",
+        origin: @current_signing_request[:sender] && `#{@current_signing_request[:sender]}.origin`,
+        options: @current_signing_request[:payload][:options] || {}
+      }
+
+      `#{@popup_port}.postMessage(#{context.to_n})`
+    end
+
+    def open_pin_popup
+      # Open extension popup programmatically
+      `chrome.action.openPopup().catch((e) => {
+        console.error('Failed to open popup:', e);
+        // Fallback: create a new window
+        chrome.windows.create({
+          url: 'popup/popup.html',
+          type: 'popup',
+          width: 400,
+          height: 300
+        });
+      })`
+    end
+
+    def ensure_native_connection(&block)
+      if @native_port
+        block.call(nil)
+        return
+      end
+
+      begin
+        @native_port = `chrome.runtime.connectNative(#{NATIVE_HOST_NAME})`
+
+        `#{@native_port}.onMessage.addListener((msg) => {
+          #{handle_native_message(`msg`)}
+        })`
+
+        `#{@native_port}.onDisconnect.addListener(() => {
+          #{handle_native_disconnect}
+        })`
+
+        # Small delay to ensure connection is established
+        `setTimeout(() => { #{block.call(nil)} }, 50)`
+      rescue => e
+        block.call("Failed to connect to native host: #{e.message}")
+      end
+    end
+
+    def send_to_native(message, send_response)
+      return unless @native_port
+
+      request_id = message[:requestId] || `message.requestId`
+      @pending_requests[request_id] = send_response
+
+      `#{@native_port}.postMessage(#{message.to_n})`
+
+      # Set timeout
+      `setTimeout(() => {
+        #{handle_request_timeout(request_id)}
+      }, #{Messaging::DEFAULT_TIMEOUT})`
+    end
+
+    def handle_native_message(message)
+      request_id = message[:requestId] || `message.requestId` || message[:request_id]
+      send_response = @pending_requests.delete(request_id)
+
+      return unless send_response
+
+      # Forward response to content script
+      `sendResponse(#{message.to_n})`
+    end
+
+    def handle_native_disconnect
+      error = `chrome.runtime.lastError?.message || 'Native host disconnected'`
+
+      @pending_requests.each do |request_id, send_response|
+        send_error(send_response, request_id, Messaging::ErrorCodes::NATIVE_HOST_NOT_FOUND, error)
+      end
+
+      @pending_requests.clear
+      @native_port = nil
+
+      # Cancel current signing request if any
+      cancel_current_signing
+    end
+
+    def handle_request_timeout(request_id)
+      send_response = @pending_requests.delete(request_id)
+      return unless send_response
+
+      send_error(send_response, request_id, Messaging::ErrorCodes::TIMEOUT, "Operation timed out")
+    end
+
+    def send_error(send_response, request_id, code, message)
+      response = Messaging.create_error(request_id, code, message)
+      `sendResponse(#{response.to_n})`
+    end
+
+    def origin_allowed?(origin)
+      # TODO: Make this configurable via extension options
+      # For now, allow localhost and https origins
+      return true if origin =~ /^https?:\/\/localhost/
+      return true if origin =~ /^https:\/\//
+
+      false
+    end
+  end
+end
+
+# Initialize background service worker
+EasySign::Background.new

--- a/plugin/src/easy_sign/content.rb
+++ b/plugin/src/easy_sign/content.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+# backtick_javascript: true
+
+require "native"
+require "easy_sign/messaging"
+
+# Content script for EasySign browser extension
+# Bridges communication between web page and extension background
+module EasySign
+  class ContentScript
+    def initialize
+      @pending_responses = {}
+      setup_page_listener
+      inject_api_script
+      puts "EasySign content script initialized"
+    end
+
+    def setup_page_listener
+      # Listen for messages from the page (inject.js)
+      `window.addEventListener('message', (event) => {
+        // Only accept messages from the same window
+        if (event.source !== window) return;
+
+        // Only accept messages targeted at the extension
+        if (!event.data || event.data.target !== #{Messaging::Targets::EXTENSION.to_n}) return;
+
+        #{handle_page_message(`event.data`, `event.origin`)}
+      })`
+    end
+
+    def handle_page_message(data, origin)
+      request_id = data[:request_id] || `data.requestId` || `data.request_id`
+      type = data[:type] || `data.type`
+
+      # Forward to background script
+      `chrome.runtime.sendMessage(#{data.to_n}, (response) => {
+        #{handle_background_response(`response`, request_id)}
+      })`
+    end
+
+    def handle_background_response(response, request_id)
+      # Check for chrome runtime errors
+      error = `chrome.runtime.lastError`
+      if error
+        response = Messaging.create_error(
+          request_id,
+          Messaging::ErrorCodes::INTERNAL_ERROR,
+          `error.message || 'Extension error'`
+        )
+      end
+
+      # Send response back to page
+      post_to_page(response)
+    end
+
+    def post_to_page(message)
+      page_message = (message || {}).merge(target: Messaging::Targets::PAGE)
+      `window.postMessage(#{page_message.to_n}, '*')`
+    end
+
+    def inject_api_script
+      # Inject the page-context script that exposes window.EasySign
+      `const script = document.createElement('script');
+       script.src = chrome.runtime.getURL('inject.js');
+       script.onload = function() {
+         this.remove();
+       };
+       (document.head || document.documentElement).appendChild(script);`
+    end
+  end
+end
+
+# Initialize content script
+EasySign::ContentScript.new

--- a/plugin/src/easy_sign/inject.rb
+++ b/plugin/src/easy_sign/inject.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+# backtick_javascript: true
+
+require "native"
+require "promise"
+require "easy_sign/messaging"
+
+# Injected page script that exposes window.EasySign API
+# This runs in the page context, not the extension context
+module EasySign
+  class API
+    DEFAULT_TIMEOUT = 120_000 # 2 minutes
+
+    def initialize
+      @pending_requests = {}
+      setup_message_listener
+    end
+
+    # Check if EasySign extension is available and token is connected
+    # @return [Promise] Resolves with availability info
+    def is_available
+      Promise.new do |resolve, reject|
+        request = create_request(Messaging::Types::AVAILABILITY_REQUEST, {})
+        send_request(request, resolve, reject, 10_000) # 10 second timeout for availability check
+      end
+    end
+
+    # Sign a PDF document
+    # @param pdf_blob [Blob] The PDF file as a Blob
+    # @param options [Hash] Signing options
+    # @option options [String] :reason Reason for signing
+    # @option options [String] :location Location of signing
+    # @option options [Boolean] :visible_signature Add visible signature annotation
+    # @option options [String] :signature_position Position (top_left, top_right, bottom_left, bottom_right)
+    # @option options [Integer] :signature_page Page number for signature
+    # @option options [Boolean] :timestamp Add RFC 3161 timestamp
+    # @return [Promise] Resolves with signed PDF Blob
+    def sign(pdf_blob, options = {})
+      Promise.new do |resolve, reject|
+        # Convert Blob to Base64
+        blob_to_base64(pdf_blob).then do |base64_data|
+          request = create_request(
+            Messaging::Types::SIGN_REQUEST,
+            { pdf_data: base64_data, options: normalize_options(options) }
+          )
+
+          # Wrap resolve to convert Base64 back to Blob
+          wrapped_resolve = ->(response) {
+            if response[:payload] && response[:payload][:signedPdfData]
+              base64_to_blob(response[:payload][:signedPdfData], "application/pdf").then do |blob|
+                resolve.call({
+                  blob: blob,
+                  signer_name: response[:payload][:signerName],
+                  signed_at: response[:payload][:signedAt],
+                  timestamped: response[:payload][:timestamped]
+                })
+              end
+            else
+              resolve.call(response)
+            end
+          }
+
+          send_request(request, wrapped_resolve, reject)
+        end.fail do |error|
+          reject.call(error)
+        end
+      end
+    end
+
+    # Verify a signed PDF document
+    # @param pdf_blob [Blob] The signed PDF file as a Blob
+    # @param options [Hash] Verification options
+    # @option options [Boolean] :check_timestamp Verify timestamp (default: true)
+    # @return [Promise] Resolves with verification result
+    def verify(pdf_blob, options = {})
+      Promise.new do |resolve, reject|
+        blob_to_base64(pdf_blob).then do |base64_data|
+          request = create_request(
+            Messaging::Types::VERIFY_REQUEST,
+            {
+              pdf_data: base64_data,
+              check_timestamp: options[:check_timestamp] != false
+            }
+          )
+
+          send_request(request, resolve, reject)
+        end.fail do |error|
+          reject.call(error)
+        end
+      end
+    end
+
+    # Cancel an ongoing signing operation
+    # @param request_id [String] The request ID to cancel
+    # @return [Promise]
+    def cancel(request_id)
+      Promise.new do |resolve, reject|
+        request = {
+          type: Messaging::Types::CANCEL_REQUEST,
+          request_id: request_id,
+          target: Messaging::Targets::EXTENSION
+        }
+
+        `window.postMessage(#{request.to_n}, '*')`
+        resolve.call({ cancelled: true })
+      end
+    end
+
+    private
+
+    def setup_message_listener
+      `window.addEventListener('message', (event) => {
+        if (event.source !== window) return;
+        if (!event.data || event.data.target !== #{Messaging::Targets::PAGE.to_n}) return;
+
+        #{handle_response(`event.data`)}
+      })`
+    end
+
+    def handle_response(data)
+      request_id = data[:request_id] || `data.requestId` || `data.request_id`
+      callbacks = @pending_requests.delete(request_id)
+
+      return unless callbacks
+
+      resolve = callbacks[:resolve]
+      reject = callbacks[:reject]
+
+      # Clear timeout
+      `clearTimeout(#{callbacks[:timeout_id]})` if callbacks[:timeout_id]
+
+      error = data[:error] || `data.error`
+      if error
+        error_obj = `new Error(#{error[:message] || `error.message` || 'Unknown error'})`
+        `#{error_obj}.code = #{error[:code] || `error.code`}`
+        reject.call(error_obj)
+      else
+        resolve.call(data)
+      end
+    end
+
+    def create_request(type, payload)
+      {
+        type: type,
+        request_id: generate_request_id,
+        payload: payload,
+        target: Messaging::Targets::EXTENSION
+      }
+    end
+
+    def send_request(request, resolve, reject, timeout = DEFAULT_TIMEOUT)
+      request_id = request[:request_id]
+
+      # Set up timeout
+      timeout_id = `setTimeout(() => {
+        #{handle_timeout(request_id)}
+      }, #{timeout})`
+
+      @pending_requests[request_id] = {
+        resolve: resolve,
+        reject: reject,
+        timeout_id: timeout_id
+      }
+
+      `window.postMessage(#{request.to_n}, '*')`
+    end
+
+    def handle_timeout(request_id)
+      callbacks = @pending_requests.delete(request_id)
+      return unless callbacks
+
+      error = `new Error('Operation timed out')`
+      `#{error}.code = 'TIMEOUT'`
+      callbacks[:reject].call(error)
+    end
+
+    def generate_request_id
+      `crypto.randomUUID ? crypto.randomUUID() :
+        Date.now().toString(36) + Math.random().toString(36).substr(2)`
+    end
+
+    def normalize_options(options)
+      # Convert Ruby-style options to camelCase for native host
+      {
+        reason: options[:reason],
+        location: options[:location],
+        visibleSignature: options[:visible_signature],
+        signaturePosition: options[:signature_position],
+        signaturePage: options[:signature_page],
+        timestamp: options[:timestamp],
+        timestampAuthority: options[:timestamp_authority]
+      }.compact
+    end
+
+    def blob_to_base64(blob)
+      Promise.new do |resolve, reject|
+        `const reader = new FileReader();
+         reader.onload = function() {
+           // Remove data URL prefix to get just base64
+           const base64 = reader.result.split(',')[1];
+           #{resolve.call(`base64`)}
+         };
+         reader.onerror = function() {
+           #{reject.call(`reader.error`)}
+         };
+         reader.readAsDataURL(#{blob});`
+      end
+    end
+
+    def base64_to_blob(base64, mime_type)
+      Promise.new do |resolve, _reject|
+        `const byteCharacters = atob(#{base64});
+         const byteNumbers = new Array(byteCharacters.length);
+         for (let i = 0; i < byteCharacters.length; i++) {
+           byteNumbers[i] = byteCharacters.charCodeAt(i);
+         }
+         const byteArray = new Uint8Array(byteNumbers);
+         const blob = new Blob([byteArray], { type: #{mime_type} });
+         #{resolve.call(`blob`)};`
+      end
+    end
+  end
+end
+
+# Expose to window object
+`window.EasySign = #{EasySign::API.new.to_n}`
+
+# Also expose individual methods directly for convenience
+`window.EasySign.sign = function(blob, options) {
+  return #{EasySign::API.new}.sign(blob, options || {});
+};
+window.EasySign.verify = function(blob, options) {
+  return #{EasySign::API.new}.verify(blob, options || {});
+};
+window.EasySign.isAvailable = function() {
+  return #{EasySign::API.new}.is_available();
+};`
+
+puts "EasySign API injected into page"

--- a/plugin/src/easy_sign/messaging.rb
+++ b/plugin/src/easy_sign/messaging.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+# backtick_javascript: true
+
+# Message protocol constants and helpers for EasySign browser extension
+module EasySign
+  module Messaging
+    # Message types
+    module Types
+      # Requests from page/content script to background
+      SIGN_REQUEST = "sign_request"
+      VERIFY_REQUEST = "verify_request"
+      AVAILABILITY_REQUEST = "availability_request"
+      CANCEL_REQUEST = "cancel_request"
+
+      # Responses from background to page/content script
+      SIGN_RESPONSE = "sign_response"
+      VERIFY_RESPONSE = "verify_response"
+      AVAILABILITY_RESPONSE = "availability_response"
+      ERROR_RESPONSE = "error"
+
+      # Internal extension messages
+      PIN_SUBMITTED = "pin_submitted"
+      PIN_CANCELLED = "pin_cancelled"
+      POPUP_READY = "popup_ready"
+    end
+
+    # Error codes matching native host protocol
+    module ErrorCodes
+      TOKEN_NOT_FOUND = "TOKEN_NOT_FOUND"
+      PIN_INCORRECT = "PIN_INCORRECT"
+      TOKEN_LOCKED = "TOKEN_LOCKED"
+      INVALID_PDF = "INVALID_PDF"
+      SIGNING_FAILED = "SIGNING_FAILED"
+      VERIFICATION_FAILED = "VERIFICATION_FAILED"
+      NATIVE_HOST_NOT_FOUND = "NATIVE_HOST_NOT_FOUND"
+      TIMEOUT = "TIMEOUT"
+      CANCELLED = "CANCELLED"
+      ORIGIN_NOT_ALLOWED = "ORIGIN_NOT_ALLOWED"
+      INTERNAL_ERROR = "INTERNAL_ERROR"
+    end
+
+    # Message targets for postMessage routing
+    module Targets
+      EXTENSION = "easy-sign-extension"
+      PAGE = "easy-sign-page"
+    end
+
+    # Default timeout for signing operations (ms)
+    DEFAULT_TIMEOUT = 120_000 # 2 minutes
+
+    # Generate unique request ID
+    def self.generate_request_id
+      # Use crypto.randomUUID if available, fallback to timestamp + random
+      `typeof crypto !== 'undefined' && crypto.randomUUID ?
+        crypto.randomUUID() :
+        Date.now().toString(36) + Math.random().toString(36).substr(2)`
+    end
+
+    # Create a request message
+    def self.create_request(type, payload = {})
+      {
+        type: type,
+        request_id: generate_request_id,
+        payload: payload,
+        timestamp: `Date.now()`
+      }
+    end
+
+    # Create a response message
+    def self.create_response(request_id, type, payload = nil, error = nil)
+      {
+        type: type,
+        request_id: request_id,
+        payload: payload,
+        error: error,
+        timestamp: `Date.now()`
+      }
+    end
+
+    # Create an error response
+    def self.create_error(request_id, code, message, details = nil)
+      create_response(
+        request_id,
+        Types::ERROR_RESPONSE,
+        nil,
+        { code: code, message: message, details: details }
+      )
+    end
+
+    # Human-readable error messages
+    ERROR_MESSAGES = {
+      ErrorCodes::TOKEN_NOT_FOUND => "Hardware token not found. Please connect your token.",
+      ErrorCodes::PIN_INCORRECT => "Incorrect PIN entered.",
+      ErrorCodes::TOKEN_LOCKED => "Token is locked. Please contact your administrator.",
+      ErrorCodes::INVALID_PDF => "The PDF file is invalid or corrupted.",
+      ErrorCodes::SIGNING_FAILED => "Failed to sign the document.",
+      ErrorCodes::VERIFICATION_FAILED => "Failed to verify the signature.",
+      ErrorCodes::NATIVE_HOST_NOT_FOUND => "EasySign native host not installed.",
+      ErrorCodes::TIMEOUT => "Operation timed out.",
+      ErrorCodes::CANCELLED => "Operation was cancelled.",
+      ErrorCodes::ORIGIN_NOT_ALLOWED => "This website is not allowed to use EasySign.",
+      ErrorCodes::INTERNAL_ERROR => "An internal error occurred."
+    }.freeze
+
+    def self.error_message(code)
+      ERROR_MESSAGES[code] || "Unknown error: #{code}"
+    end
+  end
+end

--- a/plugin/src/easy_sign/popup.rb
+++ b/plugin/src/easy_sign/popup.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+# backtick_javascript: true
+
+require "native"
+require "easy_sign/messaging"
+
+# Popup controller for PIN entry
+module EasySign
+  class Popup
+    def initialize
+      @port = nil
+      @signing_context = nil
+      setup_ui
+      connect_to_background
+    end
+
+    def setup_ui
+      # Wait for DOM to be ready
+      `document.addEventListener('DOMContentLoaded', () => {
+        #{init_ui}
+      })`
+    end
+
+    def init_ui
+      # Get UI elements
+      @pin_input = `document.getElementById('pin-input')`
+      @submit_btn = `document.getElementById('submit-btn')`
+      @cancel_btn = `document.getElementById('cancel-btn')`
+      @status_text = `document.getElementById('status-text')`
+      @origin_text = `document.getElementById('origin-text')`
+      @error_text = `document.getElementById('error-text')`
+
+      setup_event_listeners
+      focus_pin_input
+    end
+
+    def setup_event_listeners
+      # Submit button click
+      `#{@submit_btn}.addEventListener('click', () => {
+        #{submit_pin}
+      })`
+
+      # Cancel button click
+      `#{@cancel_btn}.addEventListener('click', () => {
+        #{cancel_signing}
+      })`
+
+      # Enter key in PIN input
+      `#{@pin_input}.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+          #{submit_pin}
+        }
+      })`
+
+      # Clear error on input
+      `#{@pin_input}.addEventListener('input', () => {
+        #{clear_error}
+      })`
+    end
+
+    def connect_to_background
+      @port = `chrome.runtime.connect({ name: 'popup' })`
+
+      `#{@port}.onMessage.addListener((message) => {
+        #{handle_background_message(`message`)}
+      })`
+
+      `#{@port}.onDisconnect.addListener(() => {
+        #{handle_disconnect}
+      })`
+
+      # Notify background that popup is ready
+      send_to_background({ type: Messaging::Types::POPUP_READY })
+    end
+
+    def handle_background_message(message)
+      type = message[:type] || `message.type`
+
+      case type
+      when "signing_context"
+        handle_signing_context(message)
+      when "error"
+        show_error(message[:error] || `message.error`)
+      when "pin_incorrect"
+        show_error("Incorrect PIN. Please try again.")
+        clear_pin
+        focus_pin_input
+      end
+    end
+
+    def handle_signing_context(context)
+      @signing_context = context
+      origin = context[:origin] || `context.origin`
+      options = context[:options] || `context.options` || {}
+
+      # Update UI with signing context
+      if origin && @origin_text
+        `#{@origin_text}.textContent = #{origin}`
+      end
+
+      # Show what will be signed
+      if options[:reason] && @status_text
+        `#{@status_text}.textContent = 'Reason: ' + #{options[:reason]}`
+      end
+    end
+
+    def handle_disconnect
+      # Background disconnected, close popup
+      `window.close()`
+    end
+
+    def submit_pin
+      pin = `#{@pin_input}.value`
+
+      # Validate PIN
+      if pin.nil? || `#{pin}.length === 0`
+        show_error("Please enter your PIN")
+        return
+      end
+
+      if `#{pin}.length < 4`
+        show_error("PIN must be at least 4 characters")
+        return
+      end
+
+      # Disable UI while processing
+      disable_ui
+      show_status("Signing document...")
+
+      # Send PIN to background
+      send_to_background({
+        type: Messaging::Types::PIN_SUBMITTED,
+        pin: pin
+      })
+
+      # Clear PIN from memory
+      clear_pin
+    end
+
+    def cancel_signing
+      send_to_background({ type: Messaging::Types::PIN_CANCELLED })
+      `window.close()`
+    end
+
+    def send_to_background(message)
+      return unless @port
+
+      `#{@port}.postMessage(#{message.to_n})`
+    end
+
+    def show_error(message)
+      return unless @error_text
+
+      `#{@error_text}.textContent = #{message}`
+      `#{@error_text}.style.display = 'block'`
+      enable_ui
+    end
+
+    def clear_error
+      return unless @error_text
+
+      `#{@error_text}.textContent = ''`
+      `#{@error_text}.style.display = 'none'`
+    end
+
+    def show_status(message)
+      return unless @status_text
+
+      `#{@status_text}.textContent = #{message}`
+    end
+
+    def clear_pin
+      return unless @pin_input
+
+      `#{@pin_input}.value = ''`
+    end
+
+    def focus_pin_input
+      return unless @pin_input
+
+      `#{@pin_input}.focus()`
+    end
+
+    def disable_ui
+      `#{@pin_input}.disabled = true` if @pin_input
+      `#{@submit_btn}.disabled = true` if @submit_btn
+      `#{@cancel_btn}.disabled = true` if @cancel_btn
+    end
+
+    def enable_ui
+      `#{@pin_input}.disabled = false` if @pin_input
+      `#{@submit_btn}.disabled = false` if @submit_btn
+      `#{@cancel_btn}.disabled = false` if @cancel_btn
+      focus_pin_input
+    end
+  end
+end
+
+# Initialize popup
+EasySign::Popup.new

--- a/plugin/templates/manifest.json
+++ b/plugin/templates/manifest.json
@@ -1,0 +1,58 @@
+{
+  "manifest_version": 3,
+  "name": "EasySign PDF Signer",
+  "version": "1.0.0",
+  "description": "Sign PDF documents using hardware security tokens (HSM/smart cards)",
+
+  "permissions": [
+    "nativeMessaging",
+    "storage"
+  ],
+
+  "host_permissions": [
+    "https://*/*",
+    "http://localhost/*"
+  ],
+
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+
+  "content_scripts": [
+    {
+      "matches": ["https://*/*", "http://localhost/*"],
+      "js": ["content.js"],
+      "run_at": "document_start",
+      "all_frames": false
+    }
+  ],
+
+  "web_accessible_resources": [
+    {
+      "resources": ["inject.js"],
+      "matches": ["https://*/*", "http://localhost/*"]
+    }
+  ],
+
+  "action": {
+    "default_popup": "popup/popup.html",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    },
+    "default_title": "EasySign PDF Signer"
+  },
+
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+
+  "options_ui": {
+    "page": "popup/popup.html",
+    "open_in_tab": false
+  }
+}

--- a/plugin/templates/popup.css
+++ b/plugin/templates/popup.css
@@ -1,0 +1,223 @@
+/* EasySign Popup Styles */
+
+:root {
+  --primary-color: #2563eb;
+  --primary-hover: #1d4ed8;
+  --danger-color: #dc2626;
+  --success-color: #16a34a;
+  --text-color: #1f2937;
+  --text-muted: #6b7280;
+  --bg-color: #ffffff;
+  --bg-secondary: #f3f4f6;
+  --border-color: #e5e7eb;
+  --border-radius: 8px;
+  --shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-color);
+  background: var(--bg-color);
+  width: 320px;
+  min-height: 280px;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  min-height: 280px;
+}
+
+/* Header */
+.header {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--primary-color);
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.logo svg {
+  flex-shrink: 0;
+}
+
+/* Main content */
+.main {
+  flex: 1;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.main h2 {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+/* Context info */
+.context {
+  background: var(--bg-secondary);
+  border-radius: var(--border-radius);
+  padding: 12px;
+}
+
+.context-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.context-row + .context-row {
+  margin-top: 8px;
+}
+
+.context-label {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.context-value {
+  font-size: 13px;
+  color: var(--text-color);
+  word-break: break-all;
+}
+
+.context-value.status {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* Form */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-color);
+}
+
+.pin-input {
+  width: 100%;
+  padding: 10px 12px;
+  font-size: 16px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.pin-input:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.pin-input:disabled {
+  background: var(--bg-secondary);
+  cursor: not-allowed;
+}
+
+.pin-input::placeholder {
+  color: var(--text-muted);
+}
+
+/* Error message */
+.error {
+  color: var(--danger-color);
+  font-size: 13px;
+  padding: 8px 12px;
+  background: rgba(220, 38, 38, 0.1);
+  border-radius: var(--border-radius);
+}
+
+/* Action buttons */
+.actions {
+  display: flex;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.btn {
+  flex: 1;
+  padding: 10px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  border: none;
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  transition: background-color 0.2s, opacity 0.2s;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--primary-color);
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--primary-hover);
+}
+
+.btn-secondary {
+  background: var(--bg-secondary);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: var(--border-color);
+}
+
+/* Footer */
+.footer {
+  padding: 8px 16px;
+  border-top: 1px solid var(--border-color);
+  text-align: center;
+}
+
+.footer-text {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* Loading state */
+.loading .pin-input,
+.loading .btn {
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+/* Animations */
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20%, 60% { transform: translateX(-5px); }
+  40%, 80% { transform: translateX(5px); }
+}
+
+.shake {
+  animation: shake 0.4s ease-in-out;
+}

--- a/plugin/templates/popup.html
+++ b/plugin/templates/popup.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EasySign - Enter PIN</title>
+  <link rel="stylesheet" href="popup.css">
+</head>
+<body>
+  <div class="container">
+    <header class="header">
+      <div class="logo">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M9 12L11 14L15 10M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span>EasySign</span>
+      </div>
+    </header>
+
+    <main class="main">
+      <h2>Sign Document</h2>
+
+      <div class="context">
+        <div class="context-row">
+          <span class="context-label">Website:</span>
+          <span id="origin-text" class="context-value">-</span>
+        </div>
+        <div class="context-row">
+          <span id="status-text" class="context-value status">Ready to sign</span>
+        </div>
+      </div>
+
+      <div class="form">
+        <label for="pin-input" class="label">Enter your token PIN:</label>
+        <input
+          type="password"
+          id="pin-input"
+          class="pin-input"
+          placeholder="PIN"
+          autocomplete="off"
+          autofocus
+        >
+        <div id="error-text" class="error" style="display: none;"></div>
+      </div>
+
+      <div class="actions">
+        <button id="cancel-btn" class="btn btn-secondary">Cancel</button>
+        <button id="submit-btn" class="btn btn-primary">Sign</button>
+      </div>
+    </main>
+
+    <footer class="footer">
+      <span class="footer-text">Your PIN is never stored</span>
+    </footer>
+  </div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/test/pdf_signable_test.rb
+++ b/test/pdf_signable_test.rb
@@ -158,6 +158,177 @@ class PdfVerificationTest < EasyCodeSignTest
   end
 end
 
+class PdfDeferredSigningTest < EasyCodeSignTest
+  def setup
+    super
+    @temp_pdf = Tempfile.new(["deferred_test", ".pdf"])
+    create_test_pdf(@temp_pdf.path)
+    @key = OpenSSL::PKey::RSA.new(2048)
+    @cert = create_test_cert(@key)
+    @chain = [@cert]
+    @cleanup_files = []
+  end
+
+  def teardown
+    @temp_pdf.close
+    @temp_pdf.unlink
+    @cleanup_files.each { |f| File.delete(f) if File.exist?(f) }
+    super
+  end
+
+  def test_prepare_deferred_returns_request
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    request = signable.prepare_deferred(@cert, @chain)
+    track_prepared(request)
+
+    assert_instance_of EasyCodeSign::DeferredSigningRequest, request
+    assert_instance_of String, request.digest
+    assert_equal :sha256, request.digest_algorithm
+    assert File.exist?(request.prepared_pdf_path)
+    assert_instance_of Array, request.byte_range
+    assert_equal 4, request.byte_range.size
+    assert_equal @cert.to_pem, request.certificate.to_pem
+    assert_instance_of Time, request.signing_time
+    assert_instance_of Time, request.created_at
+  end
+
+  def test_prepare_deferred_creates_valid_pdf
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    request = signable.prepare_deferred(@cert, @chain)
+    track_prepared(request)
+
+    assert File.exist?(request.prepared_pdf_path)
+    header = File.open(request.prepared_pdf_path, "rb") { |f| f.read(5) }
+    assert_equal "%PDF-", header
+  end
+
+  def test_prepare_deferred_digest_size
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    request = signable.prepare_deferred(@cert, @chain, digest_algorithm: "sha256")
+    track_prepared(request)
+
+    assert_equal 32, request.digest.bytesize
+  end
+
+  def test_prepare_deferred_sha512_digest_size
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    request = signable.prepare_deferred(@cert, @chain, digest_algorithm: "sha512")
+    track_prepared(request)
+
+    assert_equal 64, request.digest.bytesize
+  end
+
+  def test_deferred_request_serialization_roundtrip
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    request = signable.prepare_deferred(@cert, @chain)
+    track_prepared(request)
+
+    hash = request.to_h
+    restored = EasyCodeSign::DeferredSigningRequest.from_h(hash)
+
+    assert_equal request.digest, restored.digest
+    assert_equal request.digest_algorithm, restored.digest_algorithm
+    assert_equal request.prepared_pdf_path, restored.prepared_pdf_path
+    assert_equal request.byte_range, restored.byte_range
+    assert_equal request.certificate.to_pem, restored.certificate.to_pem
+    assert_equal request.certificate_chain.map(&:to_pem), restored.certificate_chain.map(&:to_pem)
+    assert_equal request.estimated_size, restored.estimated_size
+    assert_equal request.signing_time.to_i, restored.signing_time.to_i
+    assert_equal request.created_at.to_i, restored.created_at.to_i
+  end
+
+  def test_deferred_request_digest_hex_and_base64
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    request = signable.prepare_deferred(@cert, @chain)
+    track_prepared(request)
+
+    assert_equal request.digest.unpack1("H*"), request.digest_hex
+    assert_equal Base64.strict_encode64(request.digest), request.digest_base64
+  end
+
+  def test_finalize_deferred_produces_signed_pdf
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    request = signable.prepare_deferred(@cert, @chain)
+    track_prepared(request)
+
+    # Sign the digest with our test key (simulating external signer)
+    raw_signature = @key.sign_raw("sha256", request.digest)
+
+    finalizer = EasyCodeSign::Signable::PdfFile.new(request.prepared_pdf_path)
+    signed_path = finalizer.finalize_deferred(request, raw_signature)
+
+    assert File.exist?(signed_path)
+
+    # Verify the signed PDF has a signature
+    verifier_signable = EasyCodeSign::Signable::PdfFile.new(signed_path)
+    sig = verifier_signable.extract_signature
+    refute_nil sig, "Expected signed PDF to have an extractable signature"
+    refute_nil sig[:contents]
+    refute_nil sig[:byte_range]
+  end
+
+  def test_finalize_deferred_raises_on_missing_pdf
+    request = EasyCodeSign::DeferredSigningRequest.new(
+      digest: "\x00" * 32,
+      digest_algorithm: :sha256,
+      prepared_pdf_path: "/nonexistent/path/missing.pdf",
+      byte_range: [0, 100, 200, 100],
+      certificate: @cert,
+      certificate_chain: @chain,
+      estimated_size: 8192,
+      signing_time: Time.now
+    )
+
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+
+    assert_raises(EasyCodeSign::DeferredSigningError) do
+      signable.finalize_deferred(request, "fake_sig")
+    end
+  end
+
+  def test_finalize_deferred_raises_on_oversized_signature
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    request = signable.prepare_deferred(@cert, @chain)
+    track_prepared(request)
+
+    # Create a signature that's way too large for the reserved space
+    oversized_signature = "\xFF" * (request.estimated_size * 3)
+
+    finalizer = EasyCodeSign::Signable::PdfFile.new(request.prepared_pdf_path)
+
+    assert_raises(EasyCodeSign::DeferredSigningError) do
+      finalizer.finalize_deferred(request, oversized_signature)
+    end
+  end
+
+  private
+
+  def track_prepared(request)
+    @cleanup_files << request.prepared_pdf_path
+  end
+
+  def create_test_pdf(path)
+    doc = HexaPDF::Document.new
+    page = doc.pages.add
+    page.canvas.font("Helvetica", size: 12)
+    page.canvas.text("Deferred signing test document", at: [100, 700])
+    doc.write(path)
+  end
+
+  def create_test_cert(key)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 1
+    cert.subject = OpenSSL::X509::Name.parse("/CN=Test Deferred Signer")
+    cert.issuer = cert.subject
+    cert.public_key = key.public_key
+    cert.not_before = Time.now
+    cert.not_after = Time.now + 86_400
+    cert.sign(key, OpenSSL::Digest.new("SHA256"))
+    cert
+  end
+end
+
 class ExternalSigningCallbackTest < Minitest::Test
   def test_callback_receives_data_and_returns_signature
     expected_signature = "mock_signature"

--- a/test/pdf_signable_test.rb
+++ b/test/pdf_signable_test.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tempfile"
+require "hexapdf"
+
+class PdfFileSignableTest < EasyCodeSignTest
+  def setup
+    @temp_pdf = Tempfile.new(["test", ".pdf"])
+    create_test_pdf(@temp_pdf.path)
+  end
+
+  def teardown
+    @temp_pdf.close
+    @temp_pdf.unlink
+  end
+
+  def test_validates_pdf_extension
+    txt_file = Tempfile.new(["test", ".txt"])
+    txt_file.write("content")
+    txt_file.close
+
+    assert_raises(EasyCodeSign::InvalidPdfError) do
+      EasyCodeSign::Signable::PdfFile.new(txt_file.path)
+    end
+  ensure
+    txt_file.unlink
+  end
+
+  def test_validates_pdf_header
+    fake_pdf = Tempfile.new(["fake", ".pdf"])
+    fake_pdf.write("Not a PDF file")
+    fake_pdf.close
+
+    assert_raises(EasyCodeSign::InvalidPdfError) do
+      EasyCodeSign::Signable::PdfFile.new(fake_pdf.path)
+    end
+  ensure
+    fake_pdf.unlink
+  end
+
+  def test_accepts_valid_pdf_file
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    assert_instance_of EasyCodeSign::Signable::PdfFile, signable
+  end
+
+  def test_signed_returns_false_for_unsigned_pdf
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    refute signable.signed?
+  end
+
+  def test_extract_signature_returns_nil_for_unsigned
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    assert_nil signable.extract_signature
+  end
+
+  def test_prepare_for_signing_succeeds
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    signable.prepare_for_signing
+
+    assert_equal "PDF_SIGNING_PLACEHOLDER", signable.content_to_sign
+  end
+
+  def test_default_signature_config
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+
+    refute signable.signature_config[:visible]
+    assert_equal 1, signable.signature_config[:page]
+    assert_equal :bottom_right, signable.signature_config[:position]
+  end
+
+  def test_visible_signature_option
+    signable = EasyCodeSign::Signable::PdfFile.new(
+      @temp_pdf.path,
+      visible_signature: true,
+      signature_position: :top_left
+    )
+
+    assert signable.signature_config[:visible]
+    assert_equal :top_left, signable.signature_config[:position]
+  end
+
+  def test_signature_reason_and_location
+    signable = EasyCodeSign::Signable::PdfFile.new(
+      @temp_pdf.path,
+      signature_reason: "Approved",
+      signature_location: "New York"
+    )
+
+    assert_equal "Approved", signable.signature_config[:reason]
+    assert_equal "New York", signable.signature_config[:location]
+  end
+
+  def test_signature_page_option
+    signable = EasyCodeSign::Signable::PdfFile.new(
+      @temp_pdf.path,
+      signature_page: 2
+    )
+
+    assert_equal 2, signable.signature_config[:page]
+  end
+
+  def test_signable_for_returns_pdf_file
+    signable = EasyCodeSign.signable_for(@temp_pdf.path)
+    assert_instance_of EasyCodeSign::Signable::PdfFile, signable
+  end
+
+  private
+
+  def create_test_pdf(path)
+    doc = HexaPDF::Document.new
+    page = doc.pages.add
+    page.canvas.font("Helvetica", size: 12)
+    page.canvas.text("Test PDF Document", at: [100, 700])
+    doc.write(path)
+  end
+end
+
+class PdfVerificationTest < EasyCodeSignTest
+  def setup
+    @temp_pdf = Tempfile.new(["test", ".pdf"])
+    create_test_pdf(@temp_pdf.path)
+  end
+
+  def teardown
+    @temp_pdf.close
+    @temp_pdf.unlink
+  end
+
+  def test_verify_unsigned_pdf_returns_error
+    verifier = EasyCodeSign::Verifier.new
+    result = verifier.verify(@temp_pdf.path)
+
+    refute result.valid?
+    assert_any_match(result.errors, /not signed/i)
+  end
+
+  def test_verifier_creates_pdf_signable
+    verifier = EasyCodeSign::Verifier.new
+    result = verifier.verify(@temp_pdf.path)
+
+    assert_equal :pdffile, result.file_type
+  end
+
+  private
+
+  def create_test_pdf(path)
+    doc = HexaPDF::Document.new
+    page = doc.pages.add
+    page.canvas.font("Helvetica", size: 12)
+    page.canvas.text("Test PDF for verification", at: [100, 700])
+    doc.write(path)
+  end
+
+  def assert_any_match(array, pattern)
+    assert array.any? { |item| item.match?(pattern) },
+           "Expected at least one item in #{array.inspect} to match #{pattern.inspect}"
+  end
+end
+
+class ExternalSigningCallbackTest < Minitest::Test
+  def test_callback_receives_data_and_returns_signature
+    expected_signature = "mock_signature"
+    callback = EasyCodeSign::Signable::ExternalSigningCallback.new(->(data) { expected_signature })
+
+    result = callback.sign("test data", "SHA256")
+    assert_equal expected_signature, result
+  end
+
+  def test_callback_is_private
+    callback = EasyCodeSign::Signable::ExternalSigningCallback.new(->(_) { "sig" })
+    assert callback.private?
+  end
+end
+
+class ExternalSigningProxyTest < Minitest::Test
+  def setup
+    @key = OpenSSL::PKey::RSA.new(2048)
+    @cert = create_test_cert(@key)
+  end
+
+  def test_proxy_returns_precomputed_signature
+    signature = "precomputed_signature"
+    proxy = EasyCodeSign::Signable::ExternalSigningProxy.new(signature, @cert, [@cert])
+
+    result = proxy.sign("any data", "SHA256")
+    assert_equal signature, result
+  end
+
+  def test_proxy_has_certificate
+    proxy = EasyCodeSign::Signable::ExternalSigningProxy.new("sig", @cert, [@cert])
+    assert_equal @cert, proxy.certificate
+  end
+
+  def test_proxy_is_private
+    proxy = EasyCodeSign::Signable::ExternalSigningProxy.new("sig", @cert, [@cert])
+    assert proxy.private?
+  end
+
+  private
+
+  def create_test_cert(key)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 1
+    cert.subject = OpenSSL::X509::Name.parse("/CN=Test")
+    cert.issuer = cert.subject
+    cert.public_key = key.public_key
+    cert.not_before = Time.now
+    cert.not_after = Time.now + 86_400
+    cert.sign(key, OpenSSL::Digest.new("SHA256"))
+    cert
+  end
+end

--- a/test/pdf_signable_test.rb
+++ b/test/pdf_signable_test.rb
@@ -267,6 +267,57 @@ class PdfDeferredSigningTest < EasyCodeSignTest
     refute_nil sig[:byte_range]
   end
 
+  def test_signed_attributes_data_present
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    request = signable.prepare_deferred(@cert, @chain)
+    track_prepared(request)
+
+    refute_nil request.signed_attributes_data
+    refute_empty request.signed_attributes_data
+    refute_nil request.signed_attributes_base64
+  end
+
+  def test_signed_attributes_data_hash_matches_digest
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    request = signable.prepare_deferred(@cert, @chain, digest_algorithm: "sha256")
+    track_prepared(request)
+
+    computed_hash = OpenSSL::Digest::SHA256.digest(request.signed_attributes_data)
+    assert_equal request.digest, computed_hash,
+                 "SHA256(signed_attributes_data) must equal the captured digest"
+  end
+
+  def test_webcrypto_style_signing_produces_valid_pdf
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    request = signable.prepare_deferred(@cert, @chain)
+    track_prepared(request)
+
+    # Simulate WebCrypto: hash-and-sign in one step (like crypto.subtle.sign)
+    raw_signature = @key.sign("SHA256", request.signed_attributes_data)
+
+    finalizer = EasyCodeSign::Signable::PdfFile.new(request.prepared_pdf_path)
+    signed_path = finalizer.finalize_deferred(request, raw_signature)
+
+    assert File.exist?(signed_path)
+
+    verifier_signable = EasyCodeSign::Signable::PdfFile.new(signed_path)
+    sig = verifier_signable.extract_signature
+    refute_nil sig, "Expected signed PDF to have an extractable signature"
+    refute_nil sig[:contents]
+  end
+
+  def test_signed_attributes_data_serialization_roundtrip
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    request = signable.prepare_deferred(@cert, @chain)
+    track_prepared(request)
+
+    hash = request.to_h
+    assert hash.key?("signed_attributes_data"), "to_h should include signed_attributes_data"
+
+    restored = EasyCodeSign::DeferredSigningRequest.from_h(hash)
+    assert_equal request.signed_attributes_data, restored.signed_attributes_data
+  end
+
   def test_finalize_deferred_raises_on_missing_pdf
     request = EasyCodeSign::DeferredSigningRequest.new(
       digest: "\x00" * 32,

--- a/test/pdf_signable_test.rb
+++ b/test/pdf_signable_test.rb
@@ -352,6 +352,50 @@ class PdfDeferredSigningTest < EasyCodeSignTest
     end
   end
 
+  def test_finalize_deferred_with_timestamp_embeds_token
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    request = signable.prepare_deferred(@cert, @chain, timestamp_size: 4096)
+    track_prepared(request)
+
+    raw_signature = @key.sign_raw("sha256", request.digest)
+    mock_token = create_mock_timestamp_token
+
+    finalizer = EasyCodeSign::Signable::PdfFile.new(request.prepared_pdf_path)
+    signed_path = finalizer.finalize_deferred(request, raw_signature, timestamp_token: mock_token)
+
+    assert File.exist?(signed_path)
+
+    # Parse the CMS from the signed PDF and check for timestamp unsigned attribute
+    verifier_signable = EasyCodeSign::Signable::PdfFile.new(signed_path)
+    sig = verifier_signable.extract_signature
+    refute_nil sig, "Expected signed PDF to have a signature"
+
+    # Decode the CMS DER (trimming zero-padding) and look for id-aa-timeStampToken OID
+    cms_asn1 = decode_cms_from_contents(sig[:contents])
+    assert_timestamp_attribute_present(cms_asn1)
+  end
+
+  def test_finalize_deferred_without_timestamp_unchanged
+    signable = EasyCodeSign::Signable::PdfFile.new(@temp_pdf.path)
+    request = signable.prepare_deferred(@cert, @chain)
+    track_prepared(request)
+
+    raw_signature = @key.sign_raw("sha256", request.digest)
+
+    finalizer = EasyCodeSign::Signable::PdfFile.new(request.prepared_pdf_path)
+    signed_path = finalizer.finalize_deferred(request, raw_signature)
+
+    assert File.exist?(signed_path)
+
+    verifier_signable = EasyCodeSign::Signable::PdfFile.new(signed_path)
+    sig = verifier_signable.extract_signature
+    refute_nil sig
+
+    # Verify no timestamp unsigned attribute is present
+    cms_asn1 = decode_cms_from_contents(sig[:contents])
+    refute_timestamp_attribute_present(cms_asn1)
+  end
+
   private
 
   def track_prepared(request)
@@ -377,6 +421,95 @@ class PdfDeferredSigningTest < EasyCodeSignTest
     cert.not_after = Time.now + 86_400
     cert.sign(key, OpenSSL::Digest.new("SHA256"))
     cert
+  end
+
+  def create_mock_timestamp_token
+    # Build a minimal self-signed PKCS#7 structure as mock token DER
+    tsa_key = OpenSSL::PKey::RSA.new(2048)
+    tsa_cert = OpenSSL::X509::Certificate.new
+    tsa_cert.version = 2
+    tsa_cert.serial = 99
+    tsa_cert.subject = OpenSSL::X509::Name.parse("/CN=Mock TSA")
+    tsa_cert.issuer = tsa_cert.subject
+    tsa_cert.public_key = tsa_key.public_key
+    tsa_cert.not_before = Time.now
+    tsa_cert.not_after = Time.now + 86_400
+    tsa_cert.sign(tsa_key, OpenSSL::Digest.new("SHA256"))
+
+    pkcs7 = OpenSSL::PKCS7.sign(tsa_cert, tsa_key, "mock timestamp data",
+                                 [], OpenSSL::PKCS7::DETACHED | OpenSSL::PKCS7::BINARY)
+
+    EasyCodeSign::Timestamp::TimestampToken.new(
+      token_der: pkcs7.to_der,
+      timestamp: Time.now,
+      serial_number: 99,
+      policy_oid: "1.2.3.4",
+      tsa_url: "http://test.tsa"
+    )
+  end
+
+  # Decode CMS DER from PDF /Contents (which may have trailing zero-padding)
+  def decode_cms_from_contents(contents)
+    # The PDF reserves a fixed-size space; trailing zeros must be stripped.
+    # Parse just the first valid DER structure using decode_all which ignores trailing data.
+    OpenSSL::ASN1.decode(contents.sub(/\x00+\z/, ""))
+  end
+
+  # Recursively search the ASN.1 tree for the id-aa-timeStampToken OID
+  TIMESTAMP_TOKEN_OID = "1.2.840.113549.1.9.16.2.14"
+
+  def find_oid_in_asn1(asn1, target_oid)
+    if asn1.is_a?(OpenSSL::ASN1::ObjectId) && asn1.oid == target_oid
+      return true
+    end
+
+    if asn1.respond_to?(:value) && asn1.value.is_a?(Array)
+      asn1.value.any? { |child| find_oid_in_asn1(child, target_oid) }
+    else
+      false
+    end
+  end
+
+  def assert_timestamp_attribute_present(cms_asn1)
+    assert find_oid_in_asn1(cms_asn1, TIMESTAMP_TOKEN_OID),
+           "Expected CMS to contain id-aa-timeStampToken unsigned attribute"
+  end
+
+  def refute_timestamp_attribute_present(cms_asn1)
+    refute find_oid_in_asn1(cms_asn1, TIMESTAMP_TOKEN_OID),
+           "Expected CMS NOT to contain id-aa-timeStampToken unsigned attribute"
+  end
+end
+
+class PdfTimestampHandlerTest < Minitest::Test
+  def test_sign_returns_token_der_from_eager_token
+    mock_token = Struct.new(:token_der).new("mock_der_bytes")
+    handler = EasyCodeSign::Pdf::TimestampHandler.new(mock_token)
+
+    result = handler.sign(StringIO.new, [0, 0, 0, 0])
+    assert_equal "mock_der_bytes", result
+  end
+
+  def test_sign_returns_token_der_from_lazy_proc
+    mock_token = Struct.new(:token_der).new("lazy_der_bytes")
+    handler = EasyCodeSign::Pdf::TimestampHandler.new(-> { mock_token })
+
+    result = handler.sign(StringIO.new, [0, 0, 0, 0])
+    assert_equal "lazy_der_bytes", result
+  end
+
+  def test_sign_returns_nil_when_token_is_nil
+    handler = EasyCodeSign::Pdf::TimestampHandler.new(nil)
+
+    result = handler.sign(StringIO.new, [0, 0, 0, 0])
+    assert_nil result
+  end
+
+  def test_sign_returns_nil_when_lazy_proc_returns_nil
+    handler = EasyCodeSign::Pdf::TimestampHandler.new(-> { nil })
+
+    result = handler.sign(StringIO.new, [0, 0, 0, 0])
+    assert_nil result
   end
 end
 


### PR DESCRIPTION
## Summary

- Add PDF signing via HexaPDF with ByteRange-based PKCS#7 detached signatures
- Implement two-phase deferred signing API (`prepare_pdf`/`finalize_pdf`) for external signers (WebCrypto, Fortify, remote HSMs)
- Wire up RFC 3161 timestamp embedding as `id-aa-timeStampToken` unsigned attributes in CMS structures for both direct and deferred paths
- Add browser extension plugin with native messaging host for PDF signing from web applications

## Test plan

- [x] `bundle exec ruby -Ilib:test test/pdf_signable_test.rb` — all 37 PDF tests pass (117 total suite)
- [x] Timestamp embedding verified: CMS unsigned attributes contain `id-aa-timeStampToken` OID when token provided
- [x] Timestamp absence verified: no unsigned attributes when no token
- [x] `TimestampHandler` unit tests cover eager, lazy (Proc), and nil modes
- [x] Deferred signing roundtrip: prepare → sign digest → finalize → extract signature
- [x] WebCrypto-style signing path tested (hash-and-sign in one step)
- [ ] Manual: test with real TSA server and `--timestamp --tsa <url>` CLI flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)